### PR TITLE
URL Cleanup

### DIFF
--- a/doc/reference/docbook.build
+++ b/doc/reference/docbook.build
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<project name="DocBook" default="help" xmlns="http://nant.sf.net/release/0.85/nant.xsd">
+<project name="DocBook" default="help" xmlns="http://nant.sourceforge.net/release/0.85/nant.xsd">
 
   <property name="project.basedir" value="${project::get-base-directory()}" />
   <property name="project.targetdir" value="${project.basedir}\target" />

--- a/doc/reference/lib/docbook-xsl-snapshot/VERSION
+++ b/doc/reference/lib/docbook-xsl-snapshot/VERSION
@@ -1,9 +1,9 @@
 <?xml version='1.0'?> <!-- -*- nxml -*- vim: set foldlevel=2: -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-  xmlns:fm="http://freshmeat.net/projects/freshmeat-submit/"
-  xmlns:sf="http://sourceforge.net/"
+  xmlns:fm="http://freshmeat.sourceforge.net/projects/freshmeat-submit/"
+  xmlns:sf="https://sourceforge.net/"
   xmlns:dyn="http://exslt.org/dynamic"
-  xmlns:saxon="http://icl.com/saxon"
+  xmlns:saxon="https://icl.com/saxon"
   exclude-result-prefixes="fm sf"
   version='1.0'>
 
@@ -41,13 +41,13 @@ Major feature enhancements
 <!-- * Minor security fixes -->
 <!-- * Major security fixes -->
   </fm:Release-Focus>
-  <fm:Home-Page-URL>http://sourceforge.net/projects/docbook/</fm:Home-Page-URL>
-  <fm:Gzipped-Tar-URL>http://prdownloads.sourceforge.net/docbook/{DISTRONAME-VERSION}.tar.gz?download</fm:Gzipped-Tar-URL>
-  <fm:Zipped-Tar-URL>http://prdownloads.sourceforge.net/docbook/{DISTRONAME-VERSION}.zip?download</fm:Zipped-Tar-URL>
-  <fm:Bzipped-Tar-URL>http://prdownloads.sourceforge.net/docbook/{DISTRONAME-VERSION}.bz2?download</fm:Bzipped-Tar-URL>
-  <fm:Changelog-URL>http://sourceforge.net/project/shownotes.php?release_id={SFRELID}</fm:Changelog-URL>
-  <fm:CVS-URL>http://docbook.svn.sourceforge.net/viewvc/docbook/</fm:CVS-URL>
-  <fm:Mailing-List-URL>http://lists.oasis-open.org/archives/docbook-apps/</fm:Mailing-List-URL>
+  <fm:Home-Page-URL>https://sourceforge.net/projects/docbook/</fm:Home-Page-URL>
+  <fm:Gzipped-Tar-URL>https://prdownloads.sourceforge.net/docbook/{DISTRONAME-VERSION}.tar.gz?download</fm:Gzipped-Tar-URL>
+  <fm:Zipped-Tar-URL>https://prdownloads.sourceforge.net/docbook/{DISTRONAME-VERSION}.zip?download</fm:Zipped-Tar-URL>
+  <fm:Bzipped-Tar-URL>https://prdownloads.sourceforge.net/docbook/{DISTRONAME-VERSION}.bz2?download</fm:Bzipped-Tar-URL>
+  <fm:Changelog-URL>https://sourceforge.net/p/legacy_/project/shownotes.php?release_id={SFRELID}</fm:Changelog-URL>
+  <fm:CVS-URL>https://docbook.svn.sourceforge.net/viewvc/docbook/</fm:CVS-URL>
+  <fm:Mailing-List-URL>https://lists.oasis-open.org/archives/docbook-apps/</fm:Mailing-List-URL>
   <fm:Changes>This is feature release with that includes the first support of .epub output and a number of bug fixes.</fm:Changes>
 </fm:project>
 

--- a/doc/reference/lib/docbook-xsl-snapshot/common/autoidx-kimber.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/common/autoidx-kimber.xsl
@@ -16,7 +16,7 @@
      ********************************************************************
 
      This file is part of the DocBook XSL Stylesheet distribution.
-     See ../README or http://docbook.sf.net/ for copyright
+     See ../README or http://docbook.sourceforge.net/ for copyright
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/common/autoidx-kosek.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/common/autoidx-kosek.xsl
@@ -18,7 +18,7 @@
      ********************************************************************
 
      This file is part of the DocBook XSL Stylesheet distribution.
-     See ../README or http://docbook.sf.net/ for copyright
+     See ../README or http://docbook.sourceforge.net/ for copyright
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/common/charmap.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/common/charmap.xsl
@@ -1,8 +1,8 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
                 xmlns:dyn="http://exslt.org/dynamic"
-                xmlns:saxon="http://icl.com/saxon"
+                xmlns:saxon="https://icl.com/saxon"
                 xmlns:xlink="http://www.w3.org/1999/xlink"
                 exclude-result-prefixes="doc dyn saxon"
                 version='1.0'>
@@ -12,7 +12,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->
@@ -50,7 +50,7 @@
   <refpurpose>Applies an XSLT character map</refpurpose>
   <refdescription id="apply-character-map-desc">
     <para>This template applies an <link
-      xlink:href="http://www.w3.org/TR/xslt20/#character-maps"
+      xlink:href="https://www.w3.org/TR/xslt20/#character-maps"
       >XSLT character map</link>; that is, it causes certain
       individual characters to be substituted with strings of one
       or more characters. It is useful mainly for replacing
@@ -63,9 +63,9 @@
       <para>This template is a very slightly modified version of
         Jeni Tennison’s <function>replace_strings</function>
         template in the <link
-          xlink:href="http://www.dpawson.co.uk/xsl/sect2/StringReplace.html#d9351e13"
+          xlink:href="https://www.dpawson.co.uk/xsl/sect2/StringReplace.html#d9351e13"
           >multiple string replacements</link> section of Dave Pawson’s
-        <link xlink:href="http://www.dpawson.co.uk/xsl/index.html"
+        <link xlink:href="https://www.dpawson.co.uk/xsl/index.html"
           >XSLT FAQ</link>.</para>
       <para>The <function>apply-string-subst-map</function>
         template is essentially the same template as the
@@ -138,7 +138,7 @@
   <refpurpose>Reads in all or part of an XSLT character map</refpurpose>
   <refdescription id="read-character-map-desc">
     <para>The XSLT 2.0 specification describes <link
-        xlink:href="http://www.w3.org/TR/xslt20/#character-maps"
+        xlink:href="https://www.w3.org/TR/xslt20/#character-maps"
         >character maps</link> and explains how they may be used
       to allow a specific character appearing in a text or
       attribute node in a final result tree to be substituted by

--- a/doc/reference/lib/docbook-xsl-snapshot/common/common.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/common/common.xsl
@@ -1,8 +1,8 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
                 xmlns:dyn="http://exslt.org/dynamic"
-                xmlns:saxon="http://icl.com/saxon"
+                xmlns:saxon="https://icl.com/saxon"
                 exclude-result-prefixes="doc dyn saxon"
                 version='1.0'>
 
@@ -11,7 +11,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/common/entities.ent
+++ b/doc/reference/lib/docbook-xsl-snapshot/common/entities.ent
@@ -6,7 +6,7 @@
      sorting (and other things) by various templates.
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/common/gentext.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/common/gentext.xsl
@@ -1,6 +1,6 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
                 exclude-result-prefixes="doc"
                 version='1.0'>
 
@@ -9,7 +9,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/common/insertfile.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/common/insertfile.xsl
@@ -8,7 +8,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/common/l10n.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/common/l10n.xsl
@@ -9,7 +9,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      This file contains localization templates (for internationalization)

--- a/doc/reference/lib/docbook-xsl-snapshot/common/labels.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/common/labels.xsl
@@ -1,6 +1,6 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
                 exclude-result-prefixes="doc"
                 version='1.0'>
 
@@ -9,7 +9,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/common/pi.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/common/pi.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 <xsl:stylesheet
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-  xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+  xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
   xmlns:date="http://exslt.org/dates-and-times"
   xmlns:exsl="http://exslt.org/common"
   xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -14,7 +14,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/common/refentry.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/common/refentry.xsl
@@ -1,6 +1,6 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
                 xmlns:date="http://exslt.org/dates-and-times"
                 exclude-result-prefixes="doc date"
                 version='1.0'>
@@ -10,7 +10,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->
@@ -270,7 +270,7 @@
             <xsl:with-param name="source" select="$refname"/>
             <xsl:with-param name="context-desc">meta manvol</xsl:with-param>
             <xsl:with-param name="message">
-              <xsl:text>see http://docbook.sf.net/el/manvolnum</xsl:text>
+              <xsl:text>see https://www.docbook.org/tdg5/en/html/manvolnum.html</xsl:text>
             </xsl:with-param>
           </xsl:call-template>
         </xsl:if>
@@ -402,7 +402,7 @@
           <!-- * <xsl:with-param name="source" select="$refname"/> -->
           <!-- * <xsl:with-param name="context-desc">meta date</xsl:with-param> -->
           <!-- * <xsl:with-param name="message"> -->
-            <!-- * <xsl:text>see http://docbook.sf.net/el/date</xsl:text> -->
+            <!-- * <xsl:text>see https://www.docbook.org/tdg5/en/html/date.html</xsl:text> -->
           <!-- * </xsl:with-param> -->
         <!-- * </xsl:call-template> -->
       <!-- * </xsl:if> -->
@@ -795,7 +795,7 @@
     <xsl:with-param name="source" select="$refname"/>
     <xsl:with-param name="context-desc">meta source</xsl:with-param>
     <xsl:with-param name="message">
-      <xsl:text>see http://docbook.sf.net/el/productname</xsl:text>
+      <xsl:text>see https://www.docbook.org/tdg5/en/html/productname.html</xsl:text>
     </xsl:with-param>
   </xsl:call-template>
   <xsl:call-template name="log.message">
@@ -811,7 +811,7 @@
     <xsl:with-param name="source" select="$refname"/>
     <xsl:with-param name="context-desc">meta source</xsl:with-param>
     <xsl:with-param name="message">
-      <xsl:text>see http://docbook.sf.net/el/refmiscinfo</xsl:text>
+      <xsl:text>see https://www.docbook.org/tdg5/en/html/refmiscinfo.html</xsl:text>
     </xsl:with-param>
   </xsl:call-template>
 </xsl:template>
@@ -940,7 +940,7 @@
     <xsl:with-param name="source" select="$refname"/>
     <xsl:with-param name="context-desc">meta version</xsl:with-param>
     <xsl:with-param name="message">
-      <xsl:text>see http://docbook.sf.net/el/productnumber</xsl:text>
+      <xsl:text>see https://www.docbook.org/tdg5/en/html/productnumber.html</xsl:text>
     </xsl:with-param>
   </xsl:call-template>
   <xsl:call-template name="log.message">
@@ -956,7 +956,7 @@
     <xsl:with-param name="source" select="$refname"/>
     <xsl:with-param name="context-desc">meta version</xsl:with-param>
     <xsl:with-param name="message">
-      <xsl:text>see http://docbook.sf.net/el/refmiscinfo</xsl:text>
+      <xsl:text>see https://www.docbook.org/tdg5/en/html/refmiscinfo.html</xsl:text>
     </xsl:with-param>
   </xsl:call-template>
 </xsl:template>
@@ -1195,7 +1195,7 @@
     <xsl:with-param name="source" select="$refname"/>
     <xsl:with-param name="context-desc">meta manual</xsl:with-param>
     <xsl:with-param name="message">
-      <xsl:text>see http://docbook.sf.net/el/refmiscinfo</xsl:text>
+      <xsl:text>see https://www.docbook.org/tdg5/en/html/refmiscinfo.html</xsl:text>
     </xsl:with-param>
   </xsl:call-template>
 </xsl:template>

--- a/doc/reference/lib/docbook-xsl-snapshot/common/stripns.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/common/stripns.xsl
@@ -1,9 +1,9 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:ng="http://docbook.org/docbook-ng"
+                xmlns:ng="https://docbook.org/docbook-ng"
                 xmlns:db="http://docbook.org/ns/docbook"
-                xmlns:saxon="http://icl.com/saxon"
-                xmlns:NodeInfo="http://org.apache.xalan.lib.NodeInfo"
+                xmlns:saxon="https://icl.com/saxon"
+                xmlns:NodeInfo="https://org.apache.xalan.lib.NodeInfo"
                 xmlns:exsl="http://exslt.org/common"
                 exclude-result-prefixes="db ng exsl saxon NodeInfo"
                 version='1.0'>
@@ -13,7 +13,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/common/subtitles.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/common/subtitles.xsl
@@ -1,6 +1,6 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
                 exclude-result-prefixes="doc"
                 version='1.0'>
 
@@ -9,7 +9,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/common/table.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/common/table.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
                 exclude-result-prefixes="doc"
                 version="1.0">
 
@@ -9,7 +9,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/common/targets.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/common/targets.xsl
@@ -1,6 +1,6 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
                 exclude-result-prefixes="doc"
                 version='1.0'>
 
@@ -9,7 +9,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/common/titles.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/common/titles.xsl
@@ -1,6 +1,6 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
                 exclude-result-prefixes="doc"
                 version='1.0'>
 
@@ -9,7 +9,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/common/utility.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/common/utility.xsl
@@ -1,8 +1,8 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
                 xmlns:dyn="http://exslt.org/dynamic"
-                xmlns:saxon="http://icl.com/saxon"
+                xmlns:saxon="https://icl.com/saxon"
                 xmlns:xlink="http://www.w3.org/1999/xlink"
                 exclude-result-prefixes="doc dyn saxon"
                 version='1.0'>
@@ -12,7 +12,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->
@@ -242,9 +242,9 @@
     <note>
       <para>This function began as a copy of Nate Austin's
         <function>prepend-pad</function> function in the <link
-          xlink:href="http://www.dpawson.co.uk/xsl/sect2/padding.html" >Padding
+          xlink:href="https://www.dpawson.co.uk/xsl/sect2/padding.html" >Padding
           Content</link> section of Dave Pawson's <link
-          xlink:href="http://www.dpawson.co.uk/xsl/index.html" >XSLT
+          xlink:href="https://www.dpawson.co.uk/xsl/index.html" >XSLT
           FAQ</link>.</para>
     </note>
   </refdescription>

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/admon.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/admon.xsl
@@ -8,7 +8,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/annotations.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/annotations.xsl
@@ -8,7 +8,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/autoidx-kimber.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/autoidx-kimber.xsl
@@ -25,7 +25,7 @@
      ********************************************************************
 
      This file is part of the DocBook XSL Stylesheet distribution.
-     See ../README or http://docbook.sf.net/ for copyright
+     See ../README or http://docbook.sourceforge.net/ for copyright
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/autoidx-kosek.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/autoidx-kosek.xsl
@@ -16,7 +16,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
                 xmlns:rx="http://www.renderx.com/XSL/Extensions"
-                xmlns:axf="http://www.antennahouse.com/names/XSL/Extensions"
+                xmlns:axf="https://www.antennahouse.com/names/XSL/Extensions"
                 xmlns:i="urn:cz-kosek:functions:index"
                 xmlns:l="http://docbook.sourceforge.net/xmlns/l10n/1.0"
                 xmlns:func="http://exslt.org/functions"
@@ -30,7 +30,7 @@
      ********************************************************************
 
      This file is part of the DocBook XSL Stylesheet distribution.
-     See ../README or http://docbook.sf.net/ for copyright
+     See ../README or http://docbook.sourceforge.net/ for copyright
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/autoidx-ng.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/autoidx-ng.xsl
@@ -7,7 +7,7 @@
      ********************************************************************
 
      This file is part of the DocBook XSL Stylesheet distribution.
-     See ../README or http://docbook.sf.net/ for copyright
+     See ../README or http://docbook.sourceforge.net/ for copyright
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/autoidx.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/autoidx.xsl
@@ -6,7 +6,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
                 xmlns:rx="http://www.renderx.com/XSL/Extensions"
-                xmlns:axf="http://www.antennahouse.com/names/XSL/Extensions"
+                xmlns:axf="https://www.antennahouse.com/names/XSL/Extensions"
                 xmlns:exslt="http://exslt.org/common"
                 extension-element-prefixes="exslt"
                 exclude-result-prefixes="exslt"
@@ -17,7 +17,7 @@
      ********************************************************************
 
      This file is part of the DocBook XSL Stylesheet distribution.
-     See ../README or http://docbook.sf.net/ for copyright
+     See ../README or http://docbook.sourceforge.net/ for copyright
      copyright and other information.
 
      ******************************************************************** -->
@@ -330,7 +330,7 @@
 
         <xsl:choose>
           <xsl:when test="$passivetex.extensions != '0'">
-            <fotex:sort xmlns:fotex="http://www.tug.org/fotex">
+            <fotex:sort xmlns:fotex="https://www.tug.org/fotex">
               <xsl:copy-of select="$page-number-citations"/>
             </fotex:sort>
           </xsl:when>
@@ -450,7 +450,7 @@
 
         <xsl:choose>
           <xsl:when test="$passivetex.extensions != '0'">
-            <fotex:sort xmlns:fotex="http://www.tug.org/fotex">
+            <fotex:sort xmlns:fotex="https://www.tug.org/fotex">
               <xsl:copy-of select="$page-number-citations"/>
             </fotex:sort>
           </xsl:when>
@@ -573,7 +573,7 @@
 
         <xsl:choose>
           <xsl:when test="$passivetex.extensions != '0'">
-            <fotex:sort xmlns:fotex="http://www.tug.org/fotex">
+            <fotex:sort xmlns:fotex="https://www.tug.org/fotex">
               <xsl:copy-of select="$page-number-citations"/>
             </fotex:sort>
           </xsl:when>

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/autotoc.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/autotoc.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                xmlns:axf="http://www.antennahouse.com/names/XSL/Extensions"
+                xmlns:axf="https://www.antennahouse.com/names/XSL/Extensions"
                 version='1.0'>
 
 <!-- ********************************************************************
@@ -9,7 +9,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/axf.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/axf.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                xmlns:axf="http://www.antennahouse.com/names/XSL/Extensions"
+                xmlns:axf="https://www.antennahouse.com/names/XSL/Extensions"
                 version='1.0'>
 
 <!-- ********************************************************************

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/biblio-iso690.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/biblio-iso690.xsl
@@ -8,7 +8,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      The original code for processing bibliography in ISO690 style

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/biblio.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/biblio.xsl
@@ -8,7 +8,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/block.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/block.xsl
@@ -8,7 +8,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/callout.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/callout.xsl
@@ -1,9 +1,9 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                xmlns:sverb="http://nwalsh.com/xslt/ext/com.nwalsh.saxon.Verbatim"
+                xmlns:sverb="https://nwalsh.com/xslt/ext/com.nwalsh.saxon.Verbatim"
                 xmlns:xverb="com.nwalsh.xalan.Verbatim"
-                xmlns:lxslt="http://xml.apache.org/xslt"
+                xmlns:lxslt="https://xml.apache.org/xslt"
                 exclude-result-prefixes="sverb xverb lxslt"
                 version='1.0'>
 
@@ -12,7 +12,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/component.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/component.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                xmlns:axf="http://www.antennahouse.com/names/XSL/Extensions"
+                xmlns:axf="https://www.antennahouse.com/names/XSL/Extensions"
                 version='1.0'>
 
 <!-- ********************************************************************
@@ -9,7 +9,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->
@@ -52,7 +52,7 @@
   </xsl:variable>
 
   <xsl:if test="$passivetex.extensions != 0">
-    <fotex:bookmark xmlns:fotex="http://www.tug.org/fotex"
+    <fotex:bookmark xmlns:fotex="https://www.tug.org/fotex"
                     fotex-bookmark-level="2"
                     fotex-bookmark-label="{$id}">
       <xsl:value-of select="$titleabbrev"/>
@@ -676,7 +676,7 @@
     </xsl:if>
 
     <xsl:if test="$passivetex.extensions != 0">
-      <fotex:bookmark xmlns:fotex="http://www.tug.org/fotex" 
+      <fotex:bookmark xmlns:fotex="https://www.tug.org/fotex" 
                       fotex-bookmark-level="{count(ancestor::*)+2}" 
                       fotex-bookmark-label="{$id}">
         <xsl:value-of select="$titleabbrev"/>

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/division.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/division.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                xmlns:axf="http://www.antennahouse.com/names/XSL/Extensions"
+                xmlns:axf="https://www.antennahouse.com/names/XSL/Extensions"
                 version='1.0'>
 
 <!-- ********************************************************************
@@ -9,7 +9,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->
@@ -28,7 +28,7 @@
   </xsl:variable>
 
   <xsl:if test="$passivetex.extensions != 0">
-    <fotex:bookmark xmlns:fotex="http://www.tug.org/fotex"
+    <fotex:bookmark xmlns:fotex="https://www.tug.org/fotex"
                     fotex-bookmark-level="1"
                     fotex-bookmark-label="{$id}">
       <xsl:value-of select="$title"/>

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/docbook.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/docbook.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:exsl="http://exslt.org/common"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                xmlns:ng="http://docbook.org/docbook-ng"
+                xmlns:ng="https://docbook.org/docbook-ng"
                 xmlns:db="http://docbook.org/ns/docbook"
                 exclude-result-prefixes="db ng exsl"
                 version='1.0'>
@@ -17,7 +17,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/ebnf.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/ebnf.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
                 exclude-result-prefixes="doc"
                 version='1.0'>
 
@@ -10,7 +10,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/fo-rtf.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/fo-rtf.xsl
@@ -11,7 +11,7 @@
      ********************************************************************
 
      This file is part of the DocBook XSL Stylesheet distribution.
-     See ../README or http://docbook.sf.net/ for copyright
+     See ../README or http://docbook.sourceforge.net/ for copyright
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/fo.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/fo.xsl
@@ -8,7 +8,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/footnote.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/footnote.xsl
@@ -11,7 +11,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/fop.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/fop.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding="utf-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                xmlns:fox="http://xmlgraphics.apache.org/fop/extensions"
+                xmlns:fox="https://xmlgraphics.apache.org/fop/extensions"
                 version='1.0'>
 
 <!-- ********************************************************************

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/formal.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/formal.xsl
@@ -8,7 +8,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/glossary.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/glossary.xsl
@@ -12,7 +12,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/graphics.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/graphics.xsl
@@ -6,9 +6,9 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
                 xmlns:xlink="http://www.w3.org/1999/xlink"
-                xmlns:stext="http://nwalsh.com/xslt/ext/com.nwalsh.saxon.TextFactory"
+                xmlns:stext="https://nwalsh.com/xslt/ext/com.nwalsh.saxon.TextFactory"
                 xmlns:xtext="com.nwalsh.xalan.Text"
-                xmlns:lxslt="http://xml.apache.org/xslt"
+                xmlns:lxslt="https://xml.apache.org/xslt"
                 exclude-result-prefixes="xlink stext xtext lxslt"
                 extension-element-prefixes="stext xtext"
                 version='1.0'>
@@ -18,7 +18,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      Contributors:

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/highlight.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/highlight.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 		xmlns:fo="http://www.w3.org/1999/XSL/Format"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
                 exclude-result-prefixes="xslthl"
                 version='1.0'>
 
@@ -10,7 +10,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/htmltbl.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/htmltbl.xsl
@@ -8,7 +8,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/index.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/index.xsl
@@ -14,7 +14,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/info.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/info.xsl
@@ -8,7 +8,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/inline.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/inline.xsl
@@ -14,7 +14,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->
@@ -48,7 +48,7 @@
       <!-- Is it an olink ? -->
       <xsl:variable name="is.olink">
         <xsl:choose>
-	  <!-- If xlink:role="http://docbook.org/xlink/role/olink" -->
+	  <!-- If xlink:role="https://docbook.org/xlink/role/olink" -->
           <!-- and if the href contains # -->
           <xsl:when test="contains($xhref,'#') and
 	       @xlink:role = $xolink.role">1</xsl:when>

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/keywords.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/keywords.xsl
@@ -8,7 +8,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/lists.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/lists.xsl
@@ -8,7 +8,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/math.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/math.xsl
@@ -10,7 +10,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/pagesetup.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/pagesetup.xsl
@@ -8,7 +8,7 @@
      ********************************************************************
 
      This file is part of the DocBook XSL Stylesheet distribution.
-     See ../README or http://docbook.sf.net/ for copyright
+     See ../README or http://docbook.sourceforge.net/ for copyright
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/param.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/param.xsl
@@ -8,7 +8,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/pi.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/pi.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 <xsl:stylesheet
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-  xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+  xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
   xmlns:fo="http://www.w3.org/1999/XSL/Format"
   xmlns:xlink="http://www.w3.org/1999/xlink"
   exclude-result-prefixes="doc"
@@ -12,7 +12,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/profile-docbook.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/profile-docbook.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="US-ASCII"?>
 <!--This file was created automatically by xsl2profile-->
 <!--from the DocBook XSL stylesheets.-->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:exsl="http://exslt.org/common" xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:ng="http://docbook.org/docbook-ng" xmlns:db="http://docbook.org/ns/docbook" xmlns:exslt="http://exslt.org/common" exslt:dummy="dummy" ng:dummy="dummy" db:dummy="dummy" extension-element-prefixes="exslt" exclude-result-prefixes="db ng exsl exslt" version="1.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:exsl="http://exslt.org/common" xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:ng="https://docbook.org/docbook-ng" xmlns:db="http://docbook.org/ns/docbook" xmlns:exslt="http://exslt.org/common" exslt:dummy="dummy" ng:dummy="dummy" db:dummy="dummy" extension-element-prefixes="exslt" exclude-result-prefixes="db ng exsl exslt" version="1.0">
 
 <!-- It is important to use indent="no" here, otherwise verbatim -->
 <!-- environments get broken by indented tags...at least when the -->
@@ -13,7 +13,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/qandaset.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/qandaset.xsl
@@ -8,7 +8,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/refentry.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/refentry.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                xmlns:axf="http://www.antennahouse.com/names/XSL/Extensions"
+                xmlns:axf="https://www.antennahouse.com/names/XSL/Extensions"
                 version='1.0'>
 
 <!-- ********************************************************************
@@ -9,7 +9,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->
@@ -603,7 +603,7 @@
     </xsl:variable>
 
     <xsl:if test="$passivetex.extensions != 0">
-      <fotex:bookmark xmlns:fotex="http://www.tug.org/fotex" 
+      <fotex:bookmark xmlns:fotex="https://www.tug.org/fotex" 
                       fotex-bookmark-level="{$level + 2 + $offset}" 
                       fotex-bookmark-label="{$id}">
         <xsl:value-of select="$title"/>

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/sections.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/sections.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                xmlns:axf="http://www.antennahouse.com/names/XSL/Extensions"
+                xmlns:axf="https://www.antennahouse.com/names/XSL/Extensions"
                 version='1.0'>
 
 <!-- ********************************************************************
@@ -9,7 +9,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->
@@ -295,7 +295,7 @@
     </xsl:variable>
 
     <xsl:if test="$passivetex.extensions != 0">
-      <fotex:bookmark xmlns:fotex="http://www.tug.org/fotex" 
+      <fotex:bookmark xmlns:fotex="https://www.tug.org/fotex" 
                       fotex-bookmark-level="{$level + 2}" 
                       fotex-bookmark-label="{$id}">
         <xsl:value-of select="$marker.title"/>

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/synop.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/synop.xsl
@@ -12,7 +12,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/table.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/table.xsl
@@ -1,12 +1,12 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
                 xmlns:rx="http://www.renderx.com/XSL/Extensions"
-                xmlns:stbl="http://nwalsh.com/xslt/ext/com.nwalsh.saxon.Table"
+                xmlns:stbl="https://nwalsh.com/xslt/ext/com.nwalsh.saxon.Table"
                 xmlns:xtbl="com.nwalsh.xalan.Table"
-                xmlns:lxslt="http://xml.apache.org/xslt"
-                xmlns:ptbl="http://nwalsh.com/xslt/ext/xsltproc/python/Table"
+                xmlns:lxslt="https://xml.apache.org/xslt"
+                xmlns:ptbl="https://nwalsh.com/xslt/ext/xsltproc/python/Table"
                 exclude-result-prefixes="doc stbl xtbl lxslt ptbl"
                 version='1.0'>
 
@@ -17,7 +17,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/task.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/task.xsl
@@ -8,7 +8,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/titlepage.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/titlepage.xsl
@@ -8,7 +8,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/toc.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/toc.xsl
@@ -8,7 +8,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/verbatim.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/verbatim.xsl
@@ -1,9 +1,9 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                xmlns:sverb="http://nwalsh.com/xslt/ext/com.nwalsh.saxon.Verbatim"
+                xmlns:sverb="https://nwalsh.com/xslt/ext/com.nwalsh.saxon.Verbatim"
                 xmlns:xverb="com.nwalsh.xalan.Verbatim"
-                xmlns:lxslt="http://xml.apache.org/xslt"
+                xmlns:lxslt="https://xml.apache.org/xslt"
                 xmlns:exsl="http://exslt.org/common"
                 exclude-result-prefixes="sverb xverb lxslt exsl"
                 version='1.0'>
@@ -13,7 +13,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/fo/xref.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/fo/xref.xsl
@@ -11,14 +11,14 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->
 
 <!-- Use internal variable for olink xlink role for consistency -->
 <xsl:variable 
-      name="xolink.role">http://docbook.org/xlink/role/olink</xsl:variable>
+      name="xolink.role">https://docbook.org/xlink/role/olink</xsl:variable>
 
 <!-- ==================================================================== -->
 

--- a/doc/reference/lib/docbook-xsl-snapshot/highlighting/common.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/highlighting/common.xsl
@@ -2,15 +2,15 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 
 		xmlns:d="http://docbook.org/ns/docbook"
-xmlns:s6hl="http://net.sf.xslthl/ConnectorSaxon6"
-		xmlns:sbhl="http://net.sf.xslthl/ConnectorSaxonB"
-		xmlns:xhl="http://net.sf.xslthl/ConnectorXalan"
-		xmlns:saxon6="http://icl.com/saxon"
-		xmlns:saxonb="http://saxon.sf.net/"
-		xmlns:xalan="http://xml.apache.org/xalan"
+xmlns:s6hl="https://net.sf.xslthl/ConnectorSaxon6"
+		xmlns:sbhl="https://net.sf.xslthl/ConnectorSaxonB"
+		xmlns:xhl="https://net.sf.xslthl/ConnectorXalan"
+		xmlns:saxon6="https://icl.com/saxon"
+		xmlns:saxonb="http://saxon.sourceforge.net/"
+		xmlns:xalan="https://xml.apache.org/xalan"
 
 		xmlns:exsl="http://exslt.org/common"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		exclude-result-prefixes="exsl xslthl s6hl sbhl xhl d"
 		version='1.0'>
 
@@ -19,7 +19,7 @@ xmlns:s6hl="http://net.sf.xslthl/ConnectorSaxon6"
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/admon.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/admon.xsl
@@ -7,7 +7,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/autoidx-kimber.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/autoidx-kimber.xsl
@@ -21,7 +21,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/autoidx-kosek.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/autoidx-kosek.xsl
@@ -22,7 +22,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/autoidx-ng.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/autoidx-ng.xsl
@@ -7,7 +7,7 @@
      ********************************************************************
 
      This file is part of the DocBook XSL Stylesheet distribution.
-     See ../README or http://docbook.sf.net/ for copyright
+     See ../README or http://docbook.sourceforge.net/ for copyright
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/autoidx.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/autoidx.xsl
@@ -14,7 +14,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/autotoc.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/autotoc.xsl
@@ -7,7 +7,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/biblio-iso690.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/biblio-iso690.xsl
@@ -8,7 +8,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      The original code for processing bibliography in ISO690 style

--- a/doc/reference/lib/docbook-xsl-snapshot/html/biblio.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/biblio.xsl
@@ -7,7 +7,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->
@@ -807,12 +807,12 @@
   </span>
 </xsl:template>
 
-<!-- See FR #1934434 and http://doi.org -->
+<!-- See FR #1934434 and https://doi.org -->
 <xsl:template match="biblioid[@class='doi']"
               mode="bibliography.mode">
   <span>
     <xsl:apply-templates select="." mode="class.attribute"/>
-    <a href="{concat('http://dx.doi.org/', .)}">doi:<xsl:value-of select="."/></a>
+    <a href="{concat('https://dx.doi.org/', .)}">doi:<xsl:value-of select="."/></a>
   </span>
 </xsl:template>
 
@@ -1233,12 +1233,12 @@
   </span>
 </xsl:template>
 
-<!-- See FR #1934434 and http://doi.org -->
+<!-- See FR #1934434 and https://doi.org -->
 <xsl:template match="biblioid[@class='doi']"
               mode="bibliomixed.mode">
   <span>
     <xsl:apply-templates select="." mode="class.attribute"/>
-    <a href="{concat('http://dx.doi.org/', .)}">doi:<xsl:value-of select="."/></a>
+    <a href="{concat('https://dx.doi.org/', .)}">doi:<xsl:value-of select="."/></a>
   </span>
 </xsl:template>
 

--- a/doc/reference/lib/docbook-xsl-snapshot/html/block.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/block.xsl
@@ -7,7 +7,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/callout.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/callout.xsl
@@ -1,8 +1,8 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:sverb="http://nwalsh.com/xslt/ext/com.nwalsh.saxon.Verbatim"
+                xmlns:sverb="https://nwalsh.com/xslt/ext/com.nwalsh.saxon.Verbatim"
                 xmlns:xverb="xalan://com.nwalsh.xalan.Verbatim"
-                xmlns:lxslt="http://xml.apache.org/xslt"
+                xmlns:lxslt="https://xml.apache.org/xslt"
                 exclude-result-prefixes="sverb xverb lxslt"
                 version='1.0'>
 
@@ -11,7 +11,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/changebars.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/changebars.xsl
@@ -7,7 +7,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/chunk-code.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/chunk-code.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:exsl="http://exslt.org/common"
                 xmlns:cf="http://docbook.sourceforge.net/xmlns/chunkfast/1.0"
-                xmlns:ng="http://docbook.org/docbook-ng"
+                xmlns:ng="https://docbook.org/docbook-ng"
                 xmlns:db="http://docbook.org/ns/docbook"
                 exclude-result-prefixes="exsl cf ng db"
                 version="1.0">
@@ -12,7 +12,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/chunk-common.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/chunk-common.xsl
@@ -1,7 +1,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:exsl="http://exslt.org/common"
                 xmlns:cf="http://docbook.sourceforge.net/xmlns/chunkfast/1.0"
-                xmlns:ng="http://docbook.org/docbook-ng"
+                xmlns:ng="https://docbook.org/docbook-ng"
                 xmlns:db="http://docbook.org/ns/docbook"
                 version="1.0"
                 exclude-result-prefixes="exsl cf ng db">
@@ -11,7 +11,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->
@@ -157,7 +157,7 @@
   <!-- that are not first children and are not the children of first children -->
 
   <!-- Break these variables into pieces to work around
-       http://nagoya.apache.org/bugzilla/show_bug.cgi?id=6063 -->
+       https://nagoya.apache.org/bugzilla/show_bug.cgi?id=6063 -->
 
   <xsl:variable name="prev-v1"
      select="(ancestor::sect1[$chunk.section.depth &gt; 0 

--- a/doc/reference/lib/docbook-xsl-snapshot/html/chunk.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/chunk.xsl
@@ -8,7 +8,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/chunker.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/chunker.xsl
@@ -1,9 +1,9 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:saxon="http://icl.com/saxon"
-                xmlns:lxslt="http://xml.apache.org/xslt"
-                xmlns:redirect="http://xml.apache.org/xalan/redirect"
+                xmlns:saxon="https://icl.com/saxon"
+                xmlns:lxslt="https://xml.apache.org/xslt"
+                xmlns:redirect="https://xml.apache.org/xalan/redirect"
                 xmlns:exsl="http://exslt.org/common"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
 		version="1.0"
                 exclude-result-prefixes="doc"
                 extension-element-prefixes="saxon redirect lxslt exsl">
@@ -13,7 +13,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/chunkfast.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/chunkfast.xsl
@@ -9,7 +9,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/chunktoc.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/chunktoc.xsl
@@ -1,5 +1,5 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
 		version="1.0"
                 exclude-result-prefixes="doc">
 
@@ -8,7 +8,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/component.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/component.xsl
@@ -7,7 +7,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/division.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/division.xsl
@@ -7,7 +7,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/docbook.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/docbook.xsl
@@ -1,6 +1,6 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:ng="http://docbook.org/docbook-ng"
+                xmlns:ng="https://docbook.org/docbook-ng"
                 xmlns:db="http://docbook.org/ns/docbook"
                 xmlns:exsl="http://exslt.org/common"
                 xmlns:exslt="http://exslt.org/common"
@@ -16,7 +16,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/ebnf.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/ebnf.xsl
@@ -1,6 +1,6 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
                 exclude-result-prefixes="doc"
                 version='1.0'>
 
@@ -9,7 +9,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/footnote.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/footnote.xsl
@@ -9,7 +9,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/formal.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/formal.xsl
@@ -7,7 +7,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/glossary.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/glossary.xsl
@@ -11,7 +11,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/graphics.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/graphics.xsl
@@ -1,11 +1,11 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xlink="http://www.w3.org/1999/xlink"
-                xmlns:stext="http://nwalsh.com/xslt/ext/com.nwalsh.saxon.TextFactory"
-                xmlns:simg="http://nwalsh.com/xslt/ext/com.nwalsh.saxon.ImageIntrinsics"
+                xmlns:stext="https://nwalsh.com/xslt/ext/com.nwalsh.saxon.TextFactory"
+                xmlns:simg="https://nwalsh.com/xslt/ext/com.nwalsh.saxon.ImageIntrinsics"
                 xmlns:ximg="xalan://com.nwalsh.xalan.ImageIntrinsics"
                 xmlns:xtext="xalan://com.nwalsh.xalan.Text"
-                xmlns:lxslt="http://xml.apache.org/xslt"
+                xmlns:lxslt="https://xml.apache.org/xslt"
                 exclude-result-prefixes="xlink stext xtext lxslt simg ximg"
                 extension-element-prefixes="stext xtext"
                 version='1.0'>
@@ -15,7 +15,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      Contributors:

--- a/doc/reference/lib/docbook-xsl-snapshot/html/highlight.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/highlight.xsl
@@ -1,6 +1,6 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
                 exclude-result-prefixes="xslthl"
                 version='1.0'>
 
@@ -9,7 +9,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/html-rtf.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/html-rtf.xsl
@@ -10,7 +10,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/html.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/html.xsl
@@ -7,7 +7,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/htmltbl.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/htmltbl.xsl
@@ -7,7 +7,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/index.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/index.xsl
@@ -7,7 +7,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/info.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/info.xsl
@@ -7,7 +7,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/inline.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/inline.xsl
@@ -5,7 +5,7 @@
 ]>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xlink='http://www.w3.org/1999/xlink'
-                xmlns:suwl="http://nwalsh.com/xslt/ext/com.nwalsh.saxon.UnwrapLinks"
+                xmlns:suwl="https://nwalsh.com/xslt/ext/com.nwalsh.saxon.UnwrapLinks"
                 exclude-result-prefixes="xlink suwl"
                 version='1.0'>
 
@@ -14,7 +14,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->
@@ -57,7 +57,7 @@
         <!-- Is it an olink ? -->
         <xsl:variable name="is.olink">
           <xsl:choose>
-	    <!-- If xlink:role="http://docbook.org/xlink/role/olink" -->
+	    <!-- If xlink:role="https://docbook.org/xlink/role/olink" -->
             <!-- and if the href contains # -->
             <xsl:when test="contains($xhref,'#') and
 	         @xlink:role = $xolink.role">1</xsl:when>
@@ -715,7 +715,7 @@
 </xsl:template>
 
 <xsl:template name="x.generate.citerefentry.link">
-  <xsl:text>http://example.com/cgi-bin/man.cgi?</xsl:text>
+  <xsl:text>https://example.com/cgi-bin/man.cgi?</xsl:text>
   <xsl:value-of select="refentrytitle"/>
   <xsl:text>(</xsl:text>
   <xsl:value-of select="manvolnum"/>

--- a/doc/reference/lib/docbook-xsl-snapshot/html/keywords.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/keywords.xsl
@@ -7,7 +7,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/lists.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/lists.xsl
@@ -7,7 +7,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/maketoc.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/maketoc.xsl
@@ -1,5 +1,5 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
 		version="1.0"
                 exclude-result-prefixes="doc">
 
@@ -8,7 +8,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/manifest.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/manifest.xsl
@@ -1,5 +1,5 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
                 version="1.0"
                 exclude-result-prefixes="doc">
 
@@ -8,7 +8,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/math.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/math.xsl
@@ -9,7 +9,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/oldchunker.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/oldchunker.xsl
@@ -1,8 +1,8 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:saxon="http://icl.com/saxon"
-                xmlns:lxslt="http://xml.apache.org/xslt"
-                xmlns:redirect="http://xml.apache.org/xalan/redirect"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:saxon="https://icl.com/saxon"
+                xmlns:lxslt="https://xml.apache.org/xslt"
+                xmlns:redirect="https://xml.apache.org/xalan/redirect"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
 		version="1.1"
                 exclude-result-prefixes="doc"
                 extension-element-prefixes="saxon redirect lxslt">
@@ -12,7 +12,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/onechunk.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/onechunk.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
                 version="1.0"
                 exclude-result-prefixes="doc">
 
@@ -9,7 +9,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/param.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/param.xsl
@@ -7,7 +7,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/pi.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/pi.xsl
@@ -1,6 +1,6 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
                 xmlns:xlink="http://www.w3.org/1999/xlink"
                 exclude-result-prefixes="doc"
                 version='1.0'>
@@ -10,7 +10,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/profile-chunk-code.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/profile-chunk-code.xsl
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="US-ASCII"?>
 <!--This file was created automatically by xsl2profile-->
 <!--from the DocBook XSL stylesheets.-->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:exsl="http://exslt.org/common" xmlns:cf="http://docbook.sourceforge.net/xmlns/chunkfast/1.0" xmlns:ng="http://docbook.org/docbook-ng" xmlns:db="http://docbook.org/ns/docbook" xmlns:exslt="http://exslt.org/common" exslt:dummy="dummy" ng:dummy="dummy" db:dummy="dummy" extension-element-prefixes="exslt" exclude-result-prefixes="exsl cf ng db exslt" version="1.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:exsl="http://exslt.org/common" xmlns:cf="http://docbook.sourceforge.net/xmlns/chunkfast/1.0" xmlns:ng="https://docbook.org/docbook-ng" xmlns:db="http://docbook.org/ns/docbook" xmlns:exslt="http://exslt.org/common" exslt:dummy="dummy" ng:dummy="dummy" db:dummy="dummy" extension-element-prefixes="exslt" exclude-result-prefixes="exsl cf ng db exslt" version="1.0">
 
 <!-- ********************************************************************
      $Id: chunk-code.xsl 6942 2007-07-04 04:42:17Z xmldoc $
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/profile-chunk.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/profile-chunk.xsl
@@ -8,7 +8,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/profile-docbook.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/profile-docbook.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="US-ASCII"?>
 <!--This file was created automatically by xsl2profile-->
 <!--from the DocBook XSL stylesheets.-->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ng="http://docbook.org/docbook-ng" xmlns:db="http://docbook.org/ns/docbook" xmlns:exsl="http://exslt.org/common" xmlns:exslt="http://exslt.org/common" exslt:dummy="dummy" ng:dummy="dummy" db:dummy="dummy" extension-element-prefixes="exslt" exclude-result-prefixes="db ng exsl exslt exslt" version="1.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ng="https://docbook.org/docbook-ng" xmlns:db="http://docbook.org/ns/docbook" xmlns:exsl="http://exslt.org/common" xmlns:exslt="http://exslt.org/common" exslt:dummy="dummy" ng:dummy="dummy" db:dummy="dummy" extension-element-prefixes="exslt" exclude-result-prefixes="db ng exsl exslt exslt" version="1.0">
 
 <xsl:output method="html" encoding="ISO-8859-1" indent="no"/>
 
@@ -10,7 +10,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/profile-onechunk.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/profile-onechunk.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
                 version="1.0"
                 exclude-result-prefixes="doc">
 
@@ -9,7 +9,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/qandaset.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/qandaset.xsl
@@ -1,6 +1,6 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
                 exclude-result-prefixes="doc"
                 version='1.0'>
 
@@ -9,7 +9,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/refentry.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/refentry.xsl
@@ -7,7 +7,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/sections.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/sections.xsl
@@ -7,7 +7,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/springnet.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/springnet.xsl
@@ -100,7 +100,7 @@
       <a style="border:none;" href="http://www.springframework.net/" title="The Spring Framework">
         <img style="border:none;" src="images/xdev-spring_logo.jpg" />
       </a>
-      <a style="border:none;" href="http://www.springsource.com/" title="SpringSource">
+      <a style="border:none;" href="https://www.springsource.com/" title="SpringSource">
         <img style="border:none;position:absolute;padding-top:5px;right:42px;" src="images/S2-banner-rhs.png" />
       </a>
     </div>
@@ -210,7 +210,7 @@
                 </td>
                 <td width="20%" align="center">
                   <span style="color:white;font-size:90%;">
-                    <a href="http://www.springsource.com/" title="SpringSource">Sponsored by SpringSource</a>
+                    <a href="https://www.springsource.com/" title="SpringSource">Sponsored by SpringSource</a>
                   </span>
                 </td>
                 <td width="40%" align="right" valign="top">

--- a/doc/reference/lib/docbook-xsl-snapshot/html/synop.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/synop.xsl
@@ -10,7 +10,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/table.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/table.xsl
@@ -1,10 +1,10 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
-                xmlns:stbl="http://nwalsh.com/xslt/ext/com.nwalsh.saxon.Table"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
+                xmlns:stbl="https://nwalsh.com/xslt/ext/com.nwalsh.saxon.Table"
                 xmlns:xtbl="xalan://com.nwalsh.xalan.Table"
-                xmlns:lxslt="http://xml.apache.org/xslt"
-                xmlns:ptbl="http://nwalsh.com/xslt/ext/xsltproc/python/Table"
+                xmlns:lxslt="https://xml.apache.org/xslt"
+                xmlns:ptbl="https://nwalsh.com/xslt/ext/xsltproc/python/Table"
                 exclude-result-prefixes="doc stbl xtbl lxslt ptbl"
                 version='1.0'>
 
@@ -15,7 +15,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/task.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/task.xsl
@@ -7,7 +7,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/titlepage.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/titlepage.xsl
@@ -7,7 +7,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/toc.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/toc.xsl
@@ -7,7 +7,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/verbatim.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/verbatim.xsl
@@ -1,8 +1,8 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:sverb="http://nwalsh.com/xslt/ext/com.nwalsh.saxon.Verbatim"
+                xmlns:sverb="https://nwalsh.com/xslt/ext/com.nwalsh.saxon.Verbatim"
                 xmlns:xverb="xalan://com.nwalsh.xalan.Verbatim"
-                xmlns:lxslt="http://xml.apache.org/xslt"
+                xmlns:lxslt="https://xml.apache.org/xslt"
                 xmlns:exsl="http://exslt.org/common"
                 exclude-result-prefixes="sverb xverb lxslt exsl"
                 version='1.0'>
@@ -12,7 +12,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->

--- a/doc/reference/lib/docbook-xsl-snapshot/html/xref.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/html/xref.xsl
@@ -1,6 +1,6 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:suwl="http://nwalsh.com/xslt/ext/com.nwalsh.saxon.UnwrapLinks"
+                xmlns:suwl="https://nwalsh.com/xslt/ext/com.nwalsh.saxon.UnwrapLinks"
                 xmlns:exsl="http://exslt.org/common"
                 xmlns:xlink='http://www.w3.org/1999/xlink'
                 exclude-result-prefixes="suwl exsl xlink"
@@ -11,14 +11,14 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      ******************************************************************** -->
 
 <!-- Use internal variable for olink xlink role for consistency -->
 <xsl:variable 
-      name="xolink.role">http://docbook.org/xlink/role/olink</xsl:variable>
+      name="xolink.role">https://docbook.org/xlink/role/olink</xsl:variable>
 
 <!-- ==================================================================== -->
 

--- a/doc/reference/lib/docbook-xsl-snapshot/htmlhelp/htmlhelp-common.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/htmlhelp/htmlhelp-common.xsl
@@ -3,11 +3,11 @@
 <!ENTITY lf '<xsl:text xmlns:xsl="http://www.w3.org/1999/XSL/Transform">&#xA;</xsl:text>'>
 ]>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-  xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+  xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
   xmlns:exsl="http://exslt.org/common"
   xmlns:set="http://exslt.org/sets"
   xmlns:h="urn:x-hex"
-  xmlns:ng="http://docbook.org/docbook-ng"
+  xmlns:ng="https://docbook.org/docbook-ng"
   xmlns:db="http://docbook.org/ns/docbook"
   version="1.0"
   exclude-result-prefixes="doc exsl set h db ng">
@@ -847,7 +847,7 @@ Enhanced decompilation=</xsl:text>
       <xsl:value-of select="$htmlhelp.hhk"/>
     </xsl:with-param>
     <xsl:with-param name="indent" select="'no'"/>
-    <xsl:with-param name="content"><xsl:text disable-output-escaping="yes"><![CDATA[<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+    <xsl:with-param name="content"><xsl:text disable-output-escaping="yes"><![CDATA[<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <HTML>
 <HEAD>
 <meta name="GENERATOR" content="Microsoft&reg; HTML Help Workshop 4.1">

--- a/doc/reference/lib/docbook-xsl-snapshot/htmlhelp/htmlhelp.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/htmlhelp/htmlhelp.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
                 xmlns:exsl="http://exslt.org/common"
                 xmlns:set="http://exslt.org/sets"
 		version="1.0"

--- a/doc/reference/lib/docbook-xsl-snapshot/htmlhelp/profile-htmlhelp-common.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/htmlhelp/profile-htmlhelp-common.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="US-ASCII"?>
 <!--This file was created automatically by xsl2profile-->
 <!--from the DocBook XSL stylesheets.-->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:doc="http://nwalsh.com/xsl/documentation/1.0" xmlns:exsl="http://exslt.org/common" xmlns:set="http://exslt.org/sets" xmlns:h="urn:x-hex" xmlns:ng="http://docbook.org/docbook-ng" xmlns:db="http://docbook.org/ns/docbook" xmlns:exslt="http://exslt.org/common" exslt:dummy="dummy" ng:dummy="dummy" db:dummy="dummy" extension-element-prefixes="exslt" version="1.0" exclude-result-prefixes="doc exsl set h db ng exslt">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:doc="https://nwalsh.com/xsl/documentation/1.0" xmlns:exsl="http://exslt.org/common" xmlns:set="http://exslt.org/sets" xmlns:h="urn:x-hex" xmlns:ng="https://docbook.org/docbook-ng" xmlns:db="http://docbook.org/ns/docbook" xmlns:exslt="http://exslt.org/common" exslt:dummy="dummy" ng:dummy="dummy" db:dummy="dummy" extension-element-prefixes="exslt" version="1.0" exclude-result-prefixes="doc exsl set h db ng exslt">
 
 <!-- ********************************************************************
      $Id: htmlhelp-common.xsl 7427 2007-09-02 16:20:14Z mzjn $
@@ -805,7 +805,7 @@ Enhanced decompilation=</xsl:text>
       <xsl:value-of select="$htmlhelp.hhk"/>
     </xsl:with-param>
     <xsl:with-param name="indent" select="'no'"/>
-    <xsl:with-param name="content"><xsl:text disable-output-escaping="yes">&lt;!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd"&gt;
+    <xsl:with-param name="content"><xsl:text disable-output-escaping="yes">&lt;!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd"&gt;
 &lt;HTML&gt;
 &lt;HEAD&gt;
 &lt;meta name="GENERATOR" content="Microsoft&amp;reg; HTML Help Workshop 4.1"&gt;

--- a/doc/reference/lib/docbook-xsl-snapshot/htmlhelp/profile-htmlhelp.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/htmlhelp/profile-htmlhelp.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
                 xmlns:exsl="http://exslt.org/common"
                 xmlns:set="http://exslt.org/sets"
 		version="1.0"

--- a/doc/reference/lib/docbook-xsl-snapshot/htmlhelp/springnet.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/htmlhelp/springnet.xsl
@@ -3,7 +3,7 @@
     This is the XSL HTML Help stylesheet for the Spring reference Documentation.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:doc="https://nwalsh.com/xsl/documentation/1.0"
                 xmlns:exsl="http://exslt.org/common"
                 xmlns:set="http://exslt.org/sets"
                 exclude-result-prefixes="doc exsl set"

--- a/doc/reference/lib/docbook-xsl-snapshot/lib/lib.xsl
+++ b/doc/reference/lib/docbook-xsl-snapshot/lib/lib.xsl
@@ -4,7 +4,7 @@
      ********************************************************************
 
      This file is part of the XSL DocBook Stylesheet distribution.
-     See ../README or http://docbook.sf.net/release/xsl/current/ for
+     See ../README or http://docbook.sourceforge.net/release/xsl/current/ for
      copyright and other information.
 
      This module implements DTD-independent functions
@@ -330,7 +330,7 @@
   <xsl:template name="str.tokenize.keep.delimiters-characters">
     <xsl:param name="string"/>
     <xsl:if test="$string">
-      <ssb:token xmlns:ssb="http://sideshowbarker.net/ns"><xsl:value-of select="substring($string, 1, 1)"/></ssb:token>
+      <ssb:token xmlns:ssb="https://sideshowbarker.net/ns"><xsl:value-of select="substring($string, 1, 1)"/></ssb:token>
       <xsl:call-template name="str.tokenize.keep.delimiters-characters">
         <xsl:with-param name="string" select="substring($string, 2)"/>
       </xsl:call-template>
@@ -342,7 +342,7 @@
     <xsl:variable name="delimiter" select="substring($delimiters, 1, 1)"/>
     <xsl:choose>
       <xsl:when test="not($delimiter)">
-        <ssb:token xmlns:ssb="http://sideshowbarker.net/ns"><xsl:value-of select="$string"/></ssb:token>
+        <ssb:token xmlns:ssb="https://sideshowbarker.net/ns"><xsl:value-of select="$string"/></ssb:token>
       </xsl:when>
       <xsl:when test="contains($string, $delimiter)">
         <xsl:if test="not(starts-with($string, $delimiter))">

--- a/doc/reference/lib/fop-0.95/lib/README.txt
+++ b/doc/reference/lib/fop-0.95/lib/README.txt
@@ -14,7 +14,7 @@ Normal Dependencies
 - Apache Jakarta Commons IO
 
     commons-io-*.jar
-    http://jakarta.apache.org/commons/io/
+    https://jakarta.apache.org/commons/io/
     (I/O routines)
     
     Apache License v2.0
@@ -22,7 +22,7 @@ Normal Dependencies
 - Apache Jakarta Commons Logging
 
     commons-logging-*.jar
-    http://jakarta.apache.org/commons/logging/
+    https://jakarta.apache.org/commons/logging/
     (Logging adapter for various logging backends like JDK 1.4 logging or Log4J)
     
     Apache License v2.0
@@ -30,7 +30,7 @@ Normal Dependencies
 - Apache Avalon Framework
 
     avalon-framework-*.jar
-    http://excalibur.apache.org/framework/
+    https://excalibur.apache.org/framework/
     (Avalon Framework, maintained by the Apache Excalibur project)
     
     Apache License v2.0
@@ -38,7 +38,7 @@ Normal Dependencies
 - Apache XML Graphics Commons
 
     xmlgraphics-commons-*.jar
-    http://xmlgraphics.apache.org/
+    https://xmlgraphics.apache.org/
     (Common Library for Apache Batik and Apache FOP)
     
     Apache License v2.0
@@ -46,7 +46,7 @@ Normal Dependencies
 - Apache Batik
 
     batik-*.jar
-    http://xmlgraphics.apache.org/batik/
+    https://xmlgraphics.apache.org/batik/
     (SVG Implementation)
     
     Apache License v2.0
@@ -54,7 +54,7 @@ Normal Dependencies
 - Apache XML Commons Externals (JAXP API)
 
     xml-apis.jar
-    http://xml.apache.org/commons/components/external/
+    https://xml.apache.org/commons/components/external/
     (the JAXP API, plus SAX and various W3C DOM Java bindings,
     maintained in XML Commons Externals)
     
@@ -63,31 +63,31 @@ Normal Dependencies
         http://www.saxproject.org/copying.html
     W3C Software Notice and License (applies to the various DOM Java bindings)
     W3C Document License (applies to the DOM documentation)
-        http://www.w3.org/Consortium/Legal/copyright-software
-        http://www.w3.org/Consortium/Legal/copyright-documents
-        http://www.w3.org/Consortium/Legal/
+        https://www.w3.org/Consortium/Legal/copyright-software
+        https://www.w3.org/Consortium/Legal/copyright-documents
+        https://www.w3.org/Consortium/Legal/
 
     xml-apis-ext-*.jar
-    http://xml.apache.org/commons/components/external/
+    https://xml.apache.org/commons/components/external/
     (additional DOM APIs from W3C, like SVG, SMIL and Simple API for CSS)
     
     Apache License v2.0 (applies to the distribution)
     W3C Software Notice and License (applies to the various DOM Java bindings)
     W3C Document License (applies to the DOM documentation)
-        http://www.w3.org/Consortium/Legal/copyright-software
-        http://www.w3.org/Consortium/Legal/copyright-documents
-        http://www.w3.org/Consortium/Legal/
+        https://www.w3.org/Consortium/Legal/copyright-software
+        https://www.w3.org/Consortium/Legal/copyright-documents
+        https://www.w3.org/Consortium/Legal/
 
 - Apache Xalan-J
 
     xalan-*.jar and serializer-*.jar
-    http://xalan.apache.org
+    https://xalan.apache.org
     (JAXP-compliant XSLT and XPath implementation)
     
     Apache License v2.0 (applies to Xalan-J)
     Apache License v1.1 (applies to Apache BCEL and Apache REGEXP bundled in the JAR)
     Historical Permission Notice and Disclaimer (applies to CUP Parser Generator)
-        http://www.opensource.org/licenses/historical.php
+        https://www.opensource.org/licenses/historical.php
         (see xalan.runtime.LICENSE.txt)
 
 
@@ -97,7 +97,7 @@ Special Dependencies
 - Apache Xerces-J
 
     xercesImpl-*.jar
-    http://xerces.apache.org
+    https://xerces.apache.org
     (JAXP-compliant XML parser and DOM Level 3 implementation)
     
     Apache License v2.0
@@ -120,10 +120,10 @@ loaded (due to Java's class loader hierarchy).
 Replacing the default implementations involves understanding the 
 "Endorsed Standards Override Mechanism".
 More information can be found here:
-http://java.sun.com/j2se/1.4.2/docs/guide/standards/index.html
+https://java.sun.com/j2se/1.4.2/docs/guide/standards/index.html
 
 See also:
-http://xml.apache.org/xalan-j/faq.html#faq-N100EF
+https://xml.apache.org/xalan-j/faq.html#faq-N100EF
 
 Essentially, you have two different possibilities:
 - add the replacement JARs in the jre/lib/endorsed directory of your JRE.
@@ -147,7 +147,7 @@ Please make sure you've read the license of each package.
 
  - JAI (Java Advanced Imaging API) 
 
-    http://java.sun.com/products/java-media/jai 	 
+    https://java.sun.com/products/java-media/jai 	 
     Java Research License and Java Distribution License (Check which one applies to you!)
     
     Currently used for:
@@ -156,7 +156,7 @@ Please make sure you've read the license of each package.
 - JEuclid (MathML implementation, for the MathML extension)
 
     http://jeuclid.sourceforge.net/
-    http://sourceforge.net/projects/jeuclid
+    https://sourceforge.net/projects/jeuclid
     Apache License v1.1
 
 
@@ -167,7 +167,7 @@ Additional development-time dependencies
 - Servlet API
 
     servlet-*.jar
-    http://jakarta.apache.org/tomcat/
+    https://jakarta.apache.org/tomcat/
     (Servlet API, javax.servlet)
     
     Apache License v1.1
@@ -175,7 +175,7 @@ Additional development-time dependencies
 - Apache Ant
 
     (not bundled, requires pre-installation)
-    http://ant.apache.org
+    https://ant.apache.org
     (XML-based build system
     
     Apache License V2.0
@@ -183,7 +183,7 @@ Additional development-time dependencies
 - JUnit
 
     (not bundled, provided by Apache Ant or your IDE)
-    http://www.junit.org
+    https://www.junit.org
     Common Public License V1.0
 
 - XMLUnit (optional)

--- a/doc/reference/lib/fop-0.95/lib/avalon-framework.NOTICE.TXT
+++ b/doc/reference/lib/fop-0.95/lib/avalon-framework.NOTICE.TXT
@@ -4,7 +4,7 @@
    =========================================================================
 
    This product is developed by the Apache Avalon Project.
-   http://avalon.apache.org
+   https://avalon.apache.org
 
    The names "Avalon" and "Merlin" must not be used to endorse or promote 
    products derived from this software without prior written permission. 

--- a/doc/reference/lib/fop-0.95/lib/batik.NOTICE.txt
+++ b/doc/reference/lib/fop-0.95/lib/batik.NOTICE.txt
@@ -2,7 +2,7 @@ Apache Batik
 Copyright 1999-2007 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 
 This software contains code from the World Wide Web Consortium (W3C) for the 
 Document Object Model API (DOM API) and SVG Document Type Definition (DTD).
@@ -12,7 +12,7 @@ Standardization for the definition of character entities used in the software's
 documentation.
 
 This product includes images from the Tango Desktop Project
-(http://tango.freedesktop.org/).
+(https://tango.freedesktop.org/).
 
 This product includes images from the Pasodoble Icon Theme
-(http://www.jesusda.com/projects/pasodoble).
+(https://www.jesusda.com/projects/pasodoble).

--- a/doc/reference/lib/fop-0.95/lib/commons-io.NOTICE.txt
+++ b/doc/reference/lib/fop-0.95/lib/commons-io.NOTICE.txt
@@ -2,5 +2,5 @@ Apache Jakarta Commons IO
 Copyright 2001-2007 The Apache Software Foundation
 
 This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 

--- a/doc/reference/lib/fop-0.95/lib/commons-logging.NOTICE.txt
+++ b/doc/reference/lib/fop-0.95/lib/commons-logging.NOTICE.txt
@@ -1,3 +1,3 @@
 This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 

--- a/doc/reference/lib/fop-0.95/lib/serializer.NOTICE.txt
+++ b/doc/reference/lib/fop-0.95/lib/serializer.NOTICE.txt
@@ -4,12 +4,12 @@
    ==  distribution.                                                      ==
    =========================================================================
 
-   This product includes software developed by IBM Corporation (http://www.ibm.com)
-   and The Apache Software Foundation (http://www.apache.org/).
+   This product includes software developed by IBM Corporation (https://www.ibm.com)
+   and The Apache Software Foundation (https://www.apache.org/).
 
    Portions of this software was originally based on the following:
      - software copyright (c) 1999-2002, Lotus Development Corporation.,
-       http://www.lotus.com.
+       https://www.lotus.com/.
      - software copyright (c) 2001-2002, Sun Microsystems.,
-       http://www.sun.com.
-     - software copyright (c) 2003, IBM Corporation., http://www.ibm.com.
+       https://www.sun.com.
+     - software copyright (c) 2003, IBM Corporation., https://www.ibm.com.

--- a/doc/reference/lib/fop-0.95/lib/xalan.BCEL.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xalan.BCEL.LICENSE.txt
@@ -18,7 +18,7 @@ Apache Software License, Version 1.1
 * 3. The end-user documentation included with the redistribution,
 *    if any, must include the following acknowledgment:
 *       "This product includes software developed by the
-*        Apache Software Foundation (http://www.apache.org/)."
+*        Apache Software Foundation (https://www.apache.org/)."
 *    Alternately, this acknowledgment may appear in the software itself,
 *    if and wherever such third-party acknowledgments normally appear.
 *
@@ -48,5 +48,5 @@ Apache Software License, Version 1.1
 * This software consists of voluntary contributions made by many
 * individuals on behalf of the Apache Software Foundation.  For more
 * information on the Apache Software Foundation, please see
-* <http://www.apache.org/>.
+* <https://www.apache.org/>.
 */

--- a/doc/reference/lib/fop-0.95/lib/xalan.NOTICE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xalan.NOTICE.txt
@@ -4,14 +4,14 @@
    =========================================================================
 
    This product includes software developed by
-   The Apache Software Foundation (http://www.apache.org/).
+   The Apache Software Foundation (https://www.apache.org/).
 
    Portions of this software was originally based on the following:
      - software copyright (c) 1999-2002, Lotus Development Corporation.,
-       http://www.lotus.com.
+       https://www.lotus.com/.
      - software copyright (c) 2001-2002, Sun Microsystems.,
-       http://www.sun.com.
-     - software copyright (c) 2003, IBM Corporation., http://www.ibm.com.
+       https://www.sun.com.
+     - software copyright (c) 2003, IBM Corporation., https://www.ibm.com.
      - voluntary contributions made by Ovidiu Predescu <ovidiu@cup.hp.com> on
        behalf of the Apache Software Foundation that was originally developed
        at Hewlett Packard Company. 

--- a/doc/reference/lib/fop-0.95/lib/xalan.regexp.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xalan.regexp.LICENSE.txt
@@ -18,7 +18,7 @@ Apache Software License, Version 1.1
 * 3. The end-user documentation included with the redistribution,
 *    if any, must include the following acknowledgment:
 *       "This product includes software developed by the
-*        Apache Software Foundation (http://www.apache.org/)."
+*        Apache Software Foundation (https://www.apache.org/)."
 *    Alternately, this acknowledgment may appear in the software itself,
 *    if and wherever such third-party acknowledgments normally appear.
 *
@@ -48,5 +48,5 @@ Apache Software License, Version 1.1
 * This software consists of voluntary contributions made by many
 * individuals on behalf of the Apache Software Foundation.  For more
 * information on the Apache Software Foundation, please see
-* <http://www.apache.org/>.
+* <https://www.apache.org/>.
 */

--- a/doc/reference/lib/fop-0.95/lib/xerces.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xerces.LICENSE.txt
@@ -20,7 +20,7 @@
  * 3. The end-user documentation included with the redistribution,
  *    if any, must include the following acknowledgment:  
  *       "This product includes software developed by the
- *        Apache Software Foundation (http://www.apache.org/)."
+ *        Apache Software Foundation (https://www.apache.org/)."
  *    Alternately, this acknowledgment may appear in the software itself,
  *    if and wherever such third-party acknowledgments normally appear.
  *
@@ -50,7 +50,7 @@
  * This software consists of voluntary contributions made by many
  * individuals on behalf of the Apache Software Foundation and was
  * originally based on software copyright (c) 1999, International
- * Business Machines, Inc., http://www.ibm.com.  For more
+ * Business Machines, Inc., https://www.ibm.com.  For more
  * information on the Apache Software Foundation, please see
- * <http://www.apache.org/>.
+ * <https://www.apache.org/>.
  */

--- a/doc/reference/lib/fop-0.95/lib/xercesImpl.NOTICE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xercesImpl.NOTICE.txt
@@ -4,11 +4,11 @@
    =========================================================================
 
    This product includes software developed by
-   The Apache Software Foundation (http://www.apache.org/).
+   The Apache Software Foundation (https://www.apache.org/).
 
    Portions of this software were originally based on the following:
-     - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
-     - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
+     - software copyright (c) 1999, IBM Corporation., https://www.ibm.com.
+     - software copyright (c) 1999, Sun Microsystems., https://www.sun.com.
      - voluntary contributions made by Paul Eng on behalf of the 
        Apache Software Foundation that were originally developed at iClick, Inc.,
        software copyright (c) 1999.

--- a/doc/reference/lib/fop-0.95/lib/xml-apis-ext.LICENSE.dom-documentation.txt
+++ b/doc/reference/lib/fop-0.95/lib/xml-apis-ext.LICENSE.dom-documentation.txt
@@ -1,11 +1,11 @@
 xml-commons/java/external/LICENSE.dom-documentation.txt $Id: LICENSE.dom-documentation.txt 226215 2005-06-03 22:49:13Z mrglavas $
 
 
-This license came from: http://www.w3.org/Consortium/Legal/copyright-documents-20021231
+This license came from: https://www.w3.org/Consortium/Legal/copyright-documents-20021231
 
 
-W3C® DOCUMENT LICENSE
-http://www.w3.org/Consortium/Legal/2002/copyright-documents-20021231
+W3Cï¿½ DOCUMENT LICENSE
+https://www.w3.org/Consortium/Legal/2002/copyright-documents-20021231
 
 Public documents on the W3C site are provided by the copyright holders under
 the following license. By using and/or copying this document, or the W3C
@@ -21,11 +21,11 @@ following on ALL copies of the document, or portions thereof, that you use:
   1. A link or URL to the original W3C document.
   2. The pre-existing copyright notice of the original author, or if it
      doesn't exist, a notice (hypertext is preferred, but a textual
-     representation is permitted) of the form: "Copyright © [$date-of-document]
+     representation is permitted) of the form: "Copyright ï¿½ [$date-of-document]
      World Wide Web Consortium, (Massachusetts Institute of Technology,
      European Research Consortium for Informatics and Mathematics, Keio
      University). All Rights Reserved.
-     http://www.w3.org/Consortium/Legal/2002/copyright-documents-20021231"
+     https://www.w3.org/Consortium/Legal/2002/copyright-documents-20021231"
   3. If it exists, the STATUS of the W3C document.
   
 When space permits, inclusion of the full text of this NOTICE should be

--- a/doc/reference/lib/fop-0.95/lib/xml-apis-ext.LICENSE.dom-software.txt
+++ b/doc/reference/lib/fop-0.95/lib/xml-apis-ext.LICENSE.dom-software.txt
@@ -1,11 +1,11 @@
 xml-commons/java/external/LICENSE.dom-software.txt $Id: LICENSE.dom-software.txt 226215 2005-06-03 22:49:13Z mrglavas $
 
 
-This license came from: http://www.w3.org/Consortium/Legal/copyright-software-20021231
+This license came from: https://www.w3.org/Consortium/Legal/copyright-software-20021231
 
 
-W3C® SOFTWARE NOTICE AND LICENSE
-http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
+W3Cï¿½ SOFTWARE NOTICE AND LICENSE
+https://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
 
 This work (and included software, documentation such as READMEs, or other
 related items) is being provided by the copyright holders under the following

--- a/doc/reference/lib/fop-0.95/lib/xml-apis-ext.LICENSE.sac.html
+++ b/doc/reference/lib/fop-0.95/lib/xml-apis-ext.LICENSE.sac.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- $Id: LICENSE.sac.html 477037 2006-11-20 04:30:53Z mrglavas $ -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+    "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <title>W3C IPR SOFTWARE NOTICE</title>
@@ -14,19 +14,19 @@
 <body>
 <h1>W3C IPR SOFTWARE NOTICE</h1>
 
-<h3>Copyright © 2002 World Wide Web Consortium, (Massachusetts Institute of
+<h3>Copyright ï¿½ 2002 World Wide Web Consortium, (Massachusetts Institute of
 Technology, Institut National de Recherche en Informatique et en Automatique,
 Keio University). All Rights Reserved.</h3>
 
 <p><b>Note:</b> The original version of the W3C Software Copyright Notice and
 License could be found at <a
-href="http://www.w3.org/Consortium/Legal/copyright-software-19980720">http://www.w3.org/Consortium/Legal/copyright-software-19980720</a></p>
+href="https://www.w3.org/Consortium/Legal/copyright-software-19980720">https://www.w3.org/Consortium/Legal/copyright-software-19980720</a></p>
 
-<h3>Copyright © 1994-2002 <a href="http://www.w3.org/">World Wide Web
-Consortium</a>, (<a href="http://www.lcs.mit.edu/">Massachusetts Institute of
-Technology</a>, <a href="http://www.inria.fr/">Institut National de Recherche
-en Informatique et en Automatique</a>, <a href="http://www.keio.ac.jp/">Keio
-University</a>). All Rights Reserved. http://www.w3.org/Consortium/Legal/</h3>
+<h3>Copyright ï¿½ 1994-2002 <a href="https://www.w3.org/">World Wide Web
+Consortium</a>, (<a href="https://www.csail.mit.edu/">Massachusetts Institute of
+Technology</a>, <a href="https://www.inria.fr/">Institut National de Recherche
+en Informatique et en Automatique</a>, <a href="https://www.keio.ac.jp/">Keio
+University</a>). All Rights Reserved. https://www.w3.org/Consortium/Legal/</h3>
 
 <p>This W3C work (including software, documents, or other related items) is
 being provided by the copyright holders under the following license. By
@@ -35,7 +35,7 @@ have read, understood, and will comply with the following terms and
 conditions:</p>
 
 <p>Permission to use, copy, and modify this software and its documentation,
-with or without modification,  for any purpose and without fee or royalty is
+with or without modification,ï¿½ for any purpose and without fee or royalty is
 hereby granted, provided that you include the following on ALL copies of the
 software and documentation or portions thereof, including modifications, that
 you make:</p>
@@ -45,13 +45,13 @@ you make:</p>
   <li>Any pre-existing intellectual property disclaimers, notices, or terms
     and conditions. If none exist, a short notice of the following form
     (hypertext is preferred, text is permitted) should be used within the body
-    of any redistributed or derivative code: "Copyright © 2002
-    <a href="http://www.w3.org/">World Wide Web Consortium</a>, (<a
-    href="http://www.lcs.mit.edu/">Massachusetts Institute of Technology</a>,
-    <a href="http://www.inria.fr/">Institut National de Recherche en
-    Informatique et en Automatique</a>, <a href="http://www.keio.ac.jp/">Keio
+    of any redistributed or derivative code: "Copyright ï¿½ 2002
+    <a href="https://www.w3.org/">World Wide Web Consortium</a>, (<a
+    href="https://www.csail.mit.edu/">Massachusetts Institute of Technology</a>,
+    <a href="https://www.inria.fr/">Institut National de Recherche en
+    Informatique et en Automatique</a>, <a href="https://www.keio.ac.jp/">Keio
     University</a>).  All Rights Reserved.
-    http://www.w3.org/Consortium/Legal/"</li>
+    https://www.w3.org/Consortium/Legal/"</li>
   <li>Notice of any changes or modifications to the W3C files, including the
     date changes were made. (We recommend you provide URIs to the location
     from which the code is derived.)</li>

--- a/doc/reference/lib/fop-0.95/lib/xml-apis-ext.NOTICE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xml-apis-ext.NOTICE.txt
@@ -8,9 +8,9 @@
    Copyright 2006 The Apache Software Foundation.
 
    This product includes software developed at
-   The Apache Software Foundation (http://www.apache.org/).
+   The Apache Software Foundation (https://www.apache.org/).
 
    Portions of this software were originally based on the following:
-     - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
-     - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
-     - software copyright (c) 2000 World Wide Web Consortium, http://www.w3.org
+     - software copyright (c) 1999, IBM Corporation., https://www.ibm.com.
+     - software copyright (c) 1999, Sun Microsystems., https://www.sun.com.
+     - software copyright (c) 2000 World Wide Web Consortium, https://www.w3.org

--- a/doc/reference/lib/fop-0.95/lib/xml-apis-ext.README.dom.txt
+++ b/doc/reference/lib/fop-0.95/lib/xml-apis-ext.README.dom.txt
@@ -25,32 +25,32 @@ including the following items in the xml-commons project:
       and all subdirectories
 
 The actual DOM Java Language Binding classes in xml-commons came from: 
-    http://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/java-binding.html
+    https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/java-binding.html
     
 The specification of DOM Level 3's various parts is at:
-    http://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/
-    http://www.w3.org/TR/2004/REC-DOM-Level-3-LS-20040407/
-    http://www.w3.org/TR/2004/NOTE-DOM-Level-3-XPath-20040226/
+    https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/
+    https://www.w3.org/TR/2004/REC-DOM-Level-3-LS-20040407/
+    https://www.w3.org/TR/2004/NOTE-DOM-Level-3-XPath-20040226/
 
 The specification of DOM Level 2's various parts is at:
-    http://www.w3.org/TR/2000/REC-DOM-Level-2-Events-20001113/
-    http://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/
-    http://www.w3.org/TR/2000/REC-DOM-Level-2-Traversal-Range-20001113/
-    http://www.w3.org/TR/2000/REC-DOM-Level-2-Views-20001113/
+    https://www.w3.org/TR/2000/REC-DOM-Level-2-Events-20001113/
+    https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/
+    https://www.w3.org/TR/2000/REC-DOM-Level-2-Traversal-Range-20001113/
+    https://www.w3.org/TR/2000/REC-DOM-Level-2-Views-20001113/
     
 The specification of DOM Level 1's various parts is at:
-    http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-html.html
+    https://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-html.html
 
 Links to all available W3C DOM Java Bindings can be found at:
-    http://www.w3.org/DOM/DOMTR
+    https://www.w3.org/DOM/DOMTR
 
 The actual classes of The Simple API for CSS (SAC) came from:
-    http://www.w3.org/Style/CSS/SAC/
-    http://www.w3.org/2002/06/sacjava-1.3.zip
+    https://www.w3.org/Style/CSS/SAC/
+    https://www.w3.org/2002/06/sacjava-1.3.zip
 
 The actual DOM Java Language Binding classes for SMIL came from:
-    http://dev.w3.org/cvsweb/java/classes/org/w3c/dom/smil/
+    https://dev.w3.org/cvsweb/java/classes/org/w3c/dom/smil/
     (both ElementTimeControl.java and TimeEvent.java were taken at revision 1.1)
 
 The actual DOM Java Language Binding classes for SVG 1.1 came from:
-    http://www.w3.org/TR/SVG11/java.html
+    https://www.w3.org/TR/SVG11/java.html

--- a/doc/reference/lib/fop-0.95/lib/xml-apis.LICENSE.DOM-documentation.html
+++ b/doc/reference/lib/fop-0.95/lib/xml-apis.LICENSE.DOM-documentation.html
@@ -5,9 +5,9 @@ xmlns="http://www.w3.org/1999/xhtml"><HEAD><TITLE>W3C Document License</TITLE>
 
 <META content="MSHTML 6.00.2800.1400" name=GENERATOR></HEAD>
 <BODY text=#000000 bgColor=#ffffff>
-<H1>W3C<SUP>®</SUP> DOCUMENT LICENSE</H1>
+<H1>W3C<SUP>ï¿½</SUP> DOCUMENT LICENSE</H1>
 <H3 id=version><A 
-href="http://www.w3.org/Consortium/Legal/2002/copyright-documents-20021231">http://www.w3.org/Consortium/Legal/2002/copyright-documents-20021231</A></H3>
+href="https://www.w3.org/Consortium/Legal/2002/copyright-documents-20021231">https://www.w3.org/Consortium/Legal/2002/copyright-documents-20021231</A></H3>
 <P>Public documents on the W3C site are provided by the copyright holders under 
 the following license. By using and/or copying this document, or the W3C 
 document from which this statement is linked, you (the licensee) agree that you 
@@ -22,13 +22,13 @@ use:</P>
   <LI>A link or URL to the original W3C document. 
   <LI>The pre-existing copyright notice of the original author, or if it doesn't 
   exist, a notice (hypertext is preferred, but a textual representation is 
-  permitted) of the form: "Copyright © [$date-of-document] <A 
-  href="http://www.w3.org/">World Wide Web Consortium</A>, (<A 
-  href="http://www.lcs.mit.edu/">Massachusetts Institute of Technology</A>, <A 
-  href="http://www.ercim.org/">European Research Consortium for Informatics and 
-  Mathematics</A>, <A href="http://www.keio.ac.jp/">Keio University</A>). All 
+  permitted) of the form: "Copyright ï¿½ [$date-of-document] <A 
+  href="https://www.w3.org/">World Wide Web Consortium</A>, (<A 
+  href="https://www.csail.mit.edu/">Massachusetts Institute of Technology</A>, <A 
+  href="https://www.ercim.eu/">European Research Consortium for Informatics and 
+  Mathematics</A>, <A href="https://www.keio.ac.jp/">Keio University</A>). All 
   Rights Reserved. <A 
-  href="http://www.w3.org/Consortium/Legal/2002/copyright-documents-20021231">http://www.w3.org/Consortium/Legal/2002/copyright-documents-20021231</A>" 
+  href="https://www.w3.org/Consortium/Legal/2002/copyright-documents-20021231">https://www.w3.org/Consortium/Legal/2002/copyright-documents-20021231</A>" 
 
   <LI><EM>If it exists</EM>, the STATUS of the W3C document. </LI></OL>
 <P>When space permits, inclusion of the full text of this <B>NOTICE</B> should 
@@ -37,7 +37,7 @@ documents, or other items or products that you create pursuant to the
 implementation of the contents of this document, or any portion thereof.</P>
 <P>No right to create modifications or derivatives of W3C documents is granted 
 pursuant to this license. However, if additional requirements (documented in the 
-<A href="http://www.w3.org/Consortium/Legal/IPR-FAQ">Copyright FAQ</A>) are 
+<A href="https://www.w3.org/Consortium/Legal/IPR-FAQ">Copyright FAQ</A>) are 
 satisfied, the right to create modifications or derivatives is&nbsp;sometimes 
 granted by the W3C to individuals complying with those requirements.</P>
 <P>THIS DOCUMENT IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO 
@@ -59,12 +59,12 @@ remain with copyright holders.</P>
 2002. This version removes the copyright ownership notice such that this license 
 can be used with materials other than those owned by the W3C, moves information 
 on style sheets, DTDs, and schemas to the <A 
-href="http://www.w3.org/Consortium/Legal/IPR-FAQ">Copyright FAQ</A>, reflects 
+href="https://www.w3.org/Consortium/Legal/IPR-FAQ">Copyright FAQ</A>, reflects 
 that ERCIM is now a host of the W3C, includes references to this specific dated 
 version of the license, and removes the ambiguous grant of "use". See the <A 
-href="http://www.w3.org/Consortium/Legal/copyright-documents-19990405">older 
+href="https://www.w3.org/Consortium/Legal/copyright-documents-19990405">older 
 formulation</A> for the policy prior to this date. Please see our <A 
-href="http://www.w3.org/Consortium/Legal/IPR-FAQ">Copyright FAQ</A> for common 
+href="https://www.w3.org/Consortium/Legal/IPR-FAQ">Copyright FAQ</A> for common 
 questions about using materials from our site, such as the translating or 
 annotating specifications. Other questions about this notice can be directed to 
 <A href="mailto:site-policy@w3.org">site-policy@w3.org</A>.</P>

--- a/doc/reference/lib/fop-0.95/lib/xml-apis.LICENSE.DOM-software.html
+++ b/doc/reference/lib/fop-0.95/lib/xml-apis.LICENSE.DOM-software.html
@@ -5,9 +5,9 @@ xmlns="http://www.w3.org/1999/xhtml"><HEAD><TITLE>W3C Software License</TITLE>
 
 <META content="MSHTML 6.00.2800.1400" name=GENERATOR></HEAD>
 <BODY text=#000000 bgColor=#ffffff>
-<H1>W3C<SUP>®</SUP> SOFTWARE NOTICE AND LICENSE</H1>
+<H1>W3C<SUP>ï¿½</SUP> SOFTWARE NOTICE AND LICENSE</H1>
 <H3 id=version><A 
-href="http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231">http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231</A></H3>
+href="https://www.w3.org/Consortium/Legal/2002/copyright-software-20021231">https://www.w3.org/Consortium/Legal/2002/copyright-software-20021231</A></H3>
 <P>This work (and included software, documentation such as READMEs, or other 
 related items) is being provided by the copyright holders under the following 
 license. By obtaining, using and/or copying this work, you (the licensee) agree 
@@ -23,7 +23,7 @@ modifications:</P>
   redistributed or derivative work. 
   <LI>Any pre-existing intellectual property disclaimers, notices, or terms and 
   conditions. If none exist, the <A 
-  href="http://www.w3.org/Consortium/Legal/2002/copyright-software-short-notice-20021231.html">W3C 
+  href="https://www.w3.org/Consortium/Legal/2002/copyright-software-short-notice-20021231.html">W3C 
   Software Short Notice</A> should be included (hypertext is preferred, text is 
   permitted) within the body of any redistributed or derivative code. 
   <LI>Notice of any changes or modifications to the files, including the date 
@@ -49,14 +49,14 @@ can be used with materials other than those owned by the W3C, reflects that
 ERCIM is now a host of the W3C, includes references to this specific dated 
 version of the license, and removes the ambiguous grant of "use". Otherwise, 
 this version is the same as the <A 
-href="http://www.w3.org/Consortium/Legal/copyright-software-19980720">previous 
+href="https://www.w3.org/Consortium/Legal/copyright-software-19980720">previous 
 version</A> and is written so as to preserve the <A 
-href="http://www.gnu.org/philosophy/license-list.html#GPLCompatibleLicenses">Free 
+href="https://www.gnu.org/philosophy/license-list.html#GPLCompatibleLicenses">Free 
 Software Foundation's assessment of GPL compatibility</A> and <A 
-href="http://www.opensource.org/licenses/W3C.php">OSI's certification</A> under 
-the <A href="http://www.opensource.org/docs/definition.php">Open Source 
+href="https://www.opensource.org/licenses/W3C.php">OSI's certification</A> under 
+the <A href="https://www.opensource.org/docs/definition.php">Open Source 
 Definition</A>. Please see our <A 
-href="http://www.w3.org/Consortium/Legal/IPR-FAQ">Copyright FAQ</A> for common 
+href="https://www.w3.org/Consortium/Legal/IPR-FAQ">Copyright FAQ</A> for common 
 questions about using materials from our site, including specific terms and 
 conditions for packages like libwww, Amaya, and Jigsaw. Other questions about 
 this notice can be directed to <A 

--- a/doc/reference/lib/fop-0.95/lib/xml-apis.NOTICE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xml-apis.NOTICE.txt
@@ -5,9 +5,9 @@
    =========================================================================
 
    This product includes software developed by The Apache Software Foundation 
-   (http://www.apache.org/).
+   (https://www.apache.org/).
 
    Portions of this software were originally based on the following:
-     - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
-     - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
-     - software copyright (c) 2000 World Wide Web Consortium, http://www.w3.org
+     - software copyright (c) 1999, IBM Corporation., https://www.ibm.com.
+     - software copyright (c) 1999, Sun Microsystems., https://www.sun.com.
+     - software copyright (c) 2000 World Wide Web Consortium, https://www.w3.org

--- a/doc/reference/lib/fop-0.95/lib/xmlgraphics-commons.NOTICE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xmlgraphics-commons.NOTICE.txt
@@ -2,4 +2,4 @@ Apache XML Graphics Commons
 Copyright 2006-2007 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).

--- a/examples/Spring/Spring.Threading.Examples/FutureExample/DelegateFactory.cs
+++ b/examples/Spring/Spring.Threading.Examples/FutureExample/DelegateFactory.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 namespace FutureExample
 {
     /// <summary>
-    /// Copied from http://kohari.org/2009/03/06/fast-late-bound-invocation-with-expression-trees/
+    /// Copied from https://kohari.org/2009/03/06/fast-late-bound-invocation-with-expression-trees/
     /// </summary>
     public static class DelegateFactory
     {

--- a/examples/Spring/Spring.Threading.Examples/FutureExample/Program.cs
+++ b/examples/Spring/Spring.Threading.Examples/FutureExample/Program.cs
@@ -14,8 +14,8 @@ namespace FutureExample
 {
 
     /// <summary>
-    /// Based on examples from http://www.dotnetcurry.com/ShowArticle.aspx?ID=489&AspxAutoDetectCookieSupport=1
-    /// and http://www.vogella.de/articles/JavaConcurrency/article.html#futures
+    /// Based on examples from https://www.dotnetcurry.com/ShowArticle.aspx?ID=489&AspxAutoDetectCookieSupport=1
+    /// and https://www.vogella.de/articles/JavaConcurrency/article.html#futures
     /// </summary>
     class Program
     {

--- a/examples/Spring/Spring.Threading.Examples/ParallelExample/Program.cs
+++ b/examples/Spring/Spring.Threading.Examples/ParallelExample/Program.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 namespace ParallelExample
 {
     /// <summary>
-    /// Example taken from http://www.dotnetcurry.com/ShowArticle.aspx?ID=489
+    /// Example taken from https://www.dotnetcurry.com/ShowArticle.aspx?ID=489
     /// </summary>
     class Program
     {

--- a/examples/Spring/Spring.Threading.Examples/Spring.Threading.Examples/Program.cs
+++ b/examples/Spring/Spring.Threading.Examples/Spring.Threading.Examples/Program.cs
@@ -5,7 +5,7 @@ using Spring.Threading.Execution;
 namespace Spring.Threading.Examples
 {
     /// <summary>
-    /// Example taken from http://www.vogella.de/articles/JavaConcurrency/article.html#threadpools
+    /// Example taken from https://www.vogella.de/articles/JavaConcurrency/article.html#threadpools
     /// </summary>
     class Program
     {

--- a/lib/java/backport-util-concurrent-2.1-src/LEGAL
+++ b/lib/java/backport-util-concurrent-2.1-src/LEGAL
@@ -1,5 +1,5 @@
 The backport-util-concurrent software has been released to the public domain, 
-as explained at: http://creativecommons.org/licenses/publicdomain.
+as explained at: https://creativecommons.org/licenses/publicdomain.
 
 Acknowledgements: backport-util-concurrent is based in large part on the public 
 domain sources from: 

--- a/lib/java/backport-util-concurrent-2.1-src/README.html
+++ b/lib/java/backport-util-concurrent-2.1-src/README.html
@@ -7,7 +7,7 @@
 
 <h1>backport-util-concurrent</h1>
 <p>Backport ot JSR 166 (java.util.concurrent) to Java 1.4</p>
-<p><a href="http://dcl.mathcs.emory.edu/util/backport-util-concurrent/">http://dcl.mathcs.emory.edu/util/backport-util-concurrent/</a></p>
+<p><a href="https://dcl.mathcs.emory.edu/util/backport-util-concurrent/">https://dcl.mathcs.emory.edu/util/backport-util-concurrent/</a></p>
 <hr class="hide">
 
 <h2>Overview</h2>
@@ -16,7 +16,7 @@
 This package is the backport of 
 <a href="http://gee.cs.oswego.edu/dl/concurrency-interest/">java.util.concurrent</a> API, 
 introduced in 
-<a href="http://java.sun.com/j2se/1.5.0/docs/guide/concurrency/overview.html">Java 5.0</a>,
+<a href="https://java.sun.com/j2se/1.5.0/docs/guide/concurrency/overview.html">Java 5.0</a>,
 to Java 1.4. The backport is based on public-domain sources from the
 <a href="http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/src/main/java/">
 JSR 166 CVS repository</a>, the
@@ -44,7 +44,7 @@ that should work with Java 5.0 simply by changing package names.
 
 <p>
 This software is released to the 
-<a href="http://creativecommons.org/licenses/publicdomain">public domain</a>,
+<a href="https://creativecommons.org/licenses/publicdomain">public domain</a>,
 in the spirit of the original code written by Doug Lea.
 The code can be used for any purpose, modified, and redistributed 
 without acknowledgment. No warranty is provided, either express or implied.
@@ -140,7 +140,7 @@ is presented below.
 <p>
 Package java.util.concurrent exploits new language features
 introduced in Java 5.0. In particular, most API classes are
-<a href="http://java.sun.com/j2se/1.5.0/docs/guide/language/generics.html">generic types</a>.
+<a href="https://java.sun.com/j2se/1.5.0/docs/guide/language/generics.html">generic types</a>.
 In the backport, they have been flattened to standard, non-generic 
 classes. Still, programs linked against the backport should compile 
 with Java 5.0 (after changing package names). Nevertheless, you may 
@@ -373,7 +373,7 @@ works fine.
 
 <p>
 
-Version 2.1 (Jan 28, 2006) [<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-2.1/backport-util-concurrent-2.1-changelog.html">CVS log</a>]
+Version 2.1 (Jan 28, 2006) [<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-2.1/backport-util-concurrent-2.1-changelog.html">CVS log</a>]
 <ul>
 <li>New features</li>
   <ul>
@@ -413,12 +413,12 @@ Version 2.1 (Jan 28, 2006) [<a href="http://www.mathcs.emory.edu/dcl/util/backpo
   </ul>
 </ul>
 
-Version 2.0_01 (Aug 3, 2005) [<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-2.0_01/backport-util-concurrent-2.0_01-changelog.html">CVS log</a>]
+Version 2.0_01 (Aug 3, 2005) [<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-2.0_01/backport-util-concurrent-2.0_01-changelog.html">CVS log</a>]
 <ul>
 <li>Compatibility fix: ConcurrentHashMap was no longer inheriting from java.util.AbstractMap, although it was in version 1.1_01. Now it does again.</li>
 <li>Licensing: new, public-domain implementation of PriorityQueue, and refactoring of backported AbstractMap so that it also contains only the public domain code.</li>
 </ul>
-Version 2.0 (Jul 6, 2005) [<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-2.0/backport-util-concurrent-2.0-changelog.html">CVS log</a>]
+Version 2.0 (Jul 6, 2005) [<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-2.0/backport-util-concurrent-2.0-changelog.html">CVS log</a>]
 <ul>
 <li>New features</li>
 <ul>
@@ -477,7 +477,7 @@ Version 2.0 (Jul 6, 2005) [<a href="http://www.mathcs.emory.edu/dcl/util/backpor
     [Collection,Map]WordLoops, CASLoops, and more</li>
 </ul>
 </ul>
-Version 1.1_01 (Feb 7, 2005) [<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-1.1_01/backport-util-concurrent-1.1_01-changelog.html">CVS log</a>]
+Version 1.1_01 (Feb 7, 2005) [<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-1.1_01/backport-util-concurrent-1.1_01-changelog.html">CVS log</a>]
 <ul>
 <li>Bugfix: race condition in the fair implementation of ReentrantLock 
 caused it to occassionally cause IllegalMonitorState exceptions. Non-fair
@@ -491,7 +491,7 @@ Thanks to Ramesh Nethi for reporting this bug and helping to track it down.</li>
 are included in the development source bundle.</li>
 </ul>
 
-Version 1.1 (Jan 21, 2005) [<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-1.1/backport-util-concurrent-1.1-changelog.html">CVS log</a>]
+Version 1.1 (Jan 21, 2005) [<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-1.1/backport-util-concurrent-1.1-changelog.html">CVS log</a>]
 <ul>
 <li>Bugfix: on Windows platforms with Java 1.4.2, the library
 were sometimes behaving as if timeouts were ignored or misinterpreted,
@@ -522,7 +522,7 @@ to tracking it down.</li>
 </li>
 </ul>
 
-Version 1.0_01 (Dec 28, 2004) [<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-1.0_01/backport-util-concurrent-1.0_01-changelog.html">CVS log</a>]
+Version 1.0_01 (Dec 28, 2004) [<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-1.0_01/backport-util-concurrent-1.0_01-changelog.html">CVS log</a>]
 <ul>
 <li>Feature: development source bundle with ant scripts allowing to build and
     test the distribution is now available for download.</li>
@@ -559,9 +559,9 @@ For more information:
 <LI>Consult the original 
     <a href="http://gee.cs.oswego.edu/dl/concurrency-interest/">
     java.util.concurrent</a> documentation and Java 5.0 
-    <a href="http://java.sun.com/j2se/1.5.0/docs/guide/concurrency/overview.html">Concurrency Utilities Overview</a></LI>
+    <a href="https://java.sun.com/j2se/1.5.0/docs/guide/concurrency/overview.html">Concurrency Utilities Overview</a></LI>
 
-<li>Check the <a href="http://dcl.mathcs.emory.edu/util/backport-util-concurrent/">project Web page</a> for updates.</li>
+<li>Check the <a href="https://dcl.mathcs.emory.edu/util/backport-util-concurrent/">project Web page</a> for updates.</li>
 
 <li>For questions, comments, and discussion, use the
 <a href="http://altair.cs.oswego.edu/mailman/listinfo/concurrency-interest">Concurrency-Interest 
@@ -574,7 +574,7 @@ e-mail directly to <a href="mailto:dawidk@mathcs.emory.edu">Dawid Kurzyniec</a>.
 </p>
 
 <hr>
-Copyright (C) 2004-2006 <a href="http://dcl.mathcs.emory.edu/">Distributed Computing Laboratory</a>, Emory University<br>
+Copyright (C) 2004-2006 <a href="https://dcl.mathcs.emory.edu/">Distributed Computing Laboratory</a>, Emory University<br>
 
 </body>
 </html>

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/AbstractMap.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/AbstractMap.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, based on public domain code written by Doug Lea
  * and publictly available documentation, and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/ArrayDeque.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/ArrayDeque.java
@@ -1,6 +1,6 @@
 /*
  * Written by Josh Bloch of Google Inc. and released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain.
+ * as explained at https://creativecommons.org/licenses/publicdomain.
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/Arrays.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/Arrays.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, based on code written by Doug Lea with assistance
  * from members of JCP JSR-166 Expert Group. Released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain.
+ * as explained at https://creativecommons.org/licenses/publicdomain.
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/Collections.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/Collections.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, on the basis of public specifications and
  * public domain sources from JSR 166, and released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain.
+ * as explained at https://creativecommons.org/licenses/publicdomain.
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/TreeMap.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/TreeMap.java
@@ -2,7 +2,7 @@
  * Written by Dawid Kurzyniec, on the basis of public specifications and
  * public domain sources from JSR 166 and the Doug Lea's collections package,
  * and released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain.
+ * as explained at https://creativecommons.org/licenses/publicdomain.
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/TreeSet.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/TreeSet.java
@@ -2,7 +2,7 @@
  * Written by Dawid Kurzyniec, on the basis of public specifications and
  * public domain sources from JSR 166 and the Doug Lea's collections package,
  * and released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain.
+ * as explained at https://creativecommons.org/licenses/publicdomain.
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/BlockingDeque.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/BlockingDeque.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentHashMap.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentHashMap.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentLinkedQueue.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentLinkedQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;
@@ -28,7 +28,7 @@ import java.util.NoSuchElementException;
  *
  * <p>This implementation employs an efficient &quot;wait-free&quot;
  * algorithm based on one described in <a
- * href="http://www.cs.rochester.edu/u/michael/PODC96.html"> Simple,
+ * href="https://www.cs.rochester.edu/u/michael/PODC96.html"> Simple,
  * Fast, and Practical Non-Blocking and Blocking Concurrent Queue
  * Algorithms</a> by Maged M. Michael and Michael L. Scott.
  *

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentSkipListMap.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentSkipListMap.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;
@@ -25,7 +25,7 @@ import java.util.Random;
  * creation time, depending on which constructor is used.
  *
  * <p>This class implements a concurrent variant of <a
- * href="http://www.cs.umd.edu/~pugh/">SkipLists</a> providing
+ * href="https://www.cs.umd.edu/~pugh/">SkipLists</a> providing
  * expected average <i>log(n)</i> time cost for the
  * <tt>containsKey</tt>, <tt>get</tt>, <tt>put</tt> and
  * <tt>remove</tt> operations and their variants.  Insertion, removal,
@@ -101,10 +101,10 @@ public class ConcurrentSkipListMap extends AbstractMap
      * The base lists use a variant of the HM linked ordered set
      * algorithm. See Tim Harris, "A pragmatic implementation of
      * non-blocking linked lists"
-     * http://www.cl.cam.ac.uk/~tlh20/publications.html and Maged
+     * https://www.cl.cam.ac.uk/~tlh20/publications.html and Maged
      * Michael "High Performance Dynamic Lock-Free Hash Tables and
      * List-Based Sets"
-     * http://www.research.ibm.com/people/m/michael/pubs.htm.  The
+     * https://www.research.ibm.com/people/m/michael/pubs.htm.  The
      * basic idea in these lists is to mark the "next" pointers of
      * deleted nodes when deleting to avoid conflicts with concurrent
      * insertions, and when traversing to keep track of triples
@@ -276,8 +276,8 @@ public class ConcurrentSkipListMap extends AbstractMap
      * For explanation of algorithms sharing at least a couple of
      * features with this one, see Mikhail Fomitchev's thesis
      * (http://www.cs.yorku.ca/~mikhail/), Keir Fraser's thesis
-     * (http://www.cl.cam.ac.uk/users/kaf24/), and Hakan Sundell's
-     * thesis (http://www.cs.chalmers.se/~phs/).
+     * (https://www.cl.cam.ac.uk/users/kaf24/), and Hakan Sundell's
+     * thesis (https://www.chalmers.se/cse).
      *
      * Given the use of tree-like index nodes, you might wonder why
      * this doesn't use some kind of search tree instead, which would

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentSkipListSet.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentSkipListSet.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/LinkedBlockingDeque.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/LinkedBlockingDeque.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/PriorityBlockingQueue.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/PriorityBlockingQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/SynchronousQueue.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/SynchronousQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/done/AtomicBoolean.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/done/AtomicBoolean.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/done/AtomicInteger.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/done/AtomicInteger.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/done/AtomicIntegerArray.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/done/AtomicIntegerArray.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/done/AtomicLong.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/done/AtomicLong.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/done/AtomicLongArray.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/done/AtomicLongArray.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/done/AtomicMarkableReference.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/done/AtomicMarkableReference.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/done/AtomicReference.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/done/AtomicReference.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/done/AtomicReferenceArray.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/done/AtomicReferenceArray.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/done/AtomicStampedReference.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/done/AtomicStampedReference.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/done/package.html
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/done/package.html
@@ -52,7 +52,7 @@ class Sequencer {
 
 <p>The memory effects for accesses and updates of atomics generally
 follow the rules for volatiles, as stated in <a
-href="http://java.sun.com/docs/books/jls/"> The Java Language
+href="https://java.sun.com/docs/books/jls/"> The Java Language
 Specification, Third Edition (17.4 Memory Model)</a>:
 
 <ul>

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/AbstractExecutorService.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/AbstractExecutorService.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/ArrayBlockingQueue.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/ArrayBlockingQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/BlockingQueue.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/BlockingQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/BrokenBarrierException.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/BrokenBarrierException.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/Callable.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/Callable.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/CancellationException.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/CancellationException.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/CompletionService.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/CompletionService.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/ConcurrentMap.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/ConcurrentMap.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/ConcurrentNavigableMap.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/ConcurrentNavigableMap.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/CopyOnWriteArrayList.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/CopyOnWriteArrayList.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, on the basis of public specifications and
  * public domain sources from JSR 166, and released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain.
+ * as explained at https://creativecommons.org/licenses/publicdomain.
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/CyclicBarrier.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/CyclicBarrier.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/DelayQueue.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/DelayQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/Delayed.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/Delayed.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/Exchanger.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/Exchanger.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/ExecutionException.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/ExecutionException.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/Executor.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/Executor.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/ExecutorCompletionService.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/ExecutorCompletionService.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/ExecutorService.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/ExecutorService.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/Future.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/Future.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/LinkedBlockingQueue.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/LinkedBlockingQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/RejectedExecutionException.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/RejectedExecutionException.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/RejectedExecutionHandler.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/RejectedExecutionHandler.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/RunnableFuture.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/RunnableFuture.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/RunnableScheduledFuture.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/RunnableScheduledFuture.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/ScheduledExecutorService.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/ScheduledExecutorService.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/ScheduledFuture.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/ScheduledFuture.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/ScheduledThreadPoolExecutor.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/ScheduledThreadPoolExecutor.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/Semaphore.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/Semaphore.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/ThreadFactory.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/ThreadFactory.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/ThreadPoolExecutor.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/ThreadPoolExecutor.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/TimeUnit.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/TimeUnit.java
@@ -1,7 +1,7 @@
 /*
   * Written by Doug Lea with assistance from members of JCP JSR-166
   * Expert Group and released to the public domain, as explained at
-  * http://creativecommons.org/licenses/publicdomain
+  * https://creativecommons.org/licenses/publicdomain
   */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/TimeoutException.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/TimeoutException.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/package.html
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/package.html
@@ -142,7 +142,7 @@ any updates since the iterator was created.
 <a name="MemoryVisibility">
 <h2> Memory Consistency Properties </h2>
 
-<a href="http://java.sun.com/docs/books/jls/third_edition/html/memory.html">
+<a href="https://java.sun.com/docs/books/jls/third_edition/html/memory.html">
 Chapter 17 of the Java Language Specification</a> defines the
 <i>happens-before</i> relation on memory operations such as reads and
 writes of shared variables.  The results of a write by one thread are

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/helpers/ThreadHelpers.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/helpers/ThreadHelpers.java
@@ -1,6 +1,6 @@
 /*
  * Written by Dawid Kurzyniec and released to the public domain, as explained
- * at http://creativecommons.org/licenses/publicdomain
+ * at https://creativecommons.org/licenses/publicdomain
  */
 package edu.emory.mathcs.backport.java.util.concurrent.helpers;
 

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/helpers/done/NanoTimer.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/helpers/done/NanoTimer.java
@@ -1,6 +1,6 @@
 /*
  * Written by Dawid Kurzyniec and released to the public domain, as explained
- * at http://creativecommons.org/licenses/publicdomain
+ * at https://creativecommons.org/licenses/publicdomain
  */
 package edu.emory.mathcs.backport.java.util.concurrent.helpers;
 

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/helpers/done/Utils.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/helpers/done/Utils.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, based on code written by Doug Lea with assistance
  * from members of JCP JSR-166 Expert Group. Released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain.
+ * as explained at https://creativecommons.org/licenses/publicdomain.
  *
  * Thanks to Craig Mattocks for suggesting to use <code>sun.misc.Perf</code>.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/done/Condition.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/done/Condition.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.locks;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/done/Lock.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/done/Lock.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.locks;
@@ -93,7 +93,7 @@ import edu.emory.mathcs.backport.java.util.concurrent.TimeUnit;
  * <h3>Memory Synchronization</h3>
  * <p>All <tt>Lock</tt> implementations <em>must</em> enforce the same
  * memory synchronization semantics as provided by the built-in monitor
- * lock, as described in <a href="http://java.sun.com/docs/books/jls/">
+ * lock, as described in <a href="https://java.sun.com/docs/books/jls/">
  * The Java Language Specification, Third Edition (17.4 Memory Model)</a>:
  * <ul>
  * <li>A successful <tt>lock</tt> operation has the same memory

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/done/ReadWriteLock.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/done/ReadWriteLock.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.locks;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/done/ReentrantLock.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/done/ReentrantLock.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.locks;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/done/ReentrantReadWriteLock.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/done/ReentrantReadWriteLock.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.locks;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/done/AbstractCollection.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/done/AbstractCollection.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, based on public domain code written by Doug Lea
  * and publictly available documentation, and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/done/AbstractList.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/done/AbstractList.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, based on public domain code written by Doug Lea
  * and publictly available documentation, and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/done/AbstractQueue.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/done/AbstractQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/done/AbstractSequentialList.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/done/AbstractSequentialList.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, based on public domain code written by Doug Lea
  * and publictly available documentation, and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/done/AbstractSet.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/done/AbstractSet.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, based on public domain code written by Doug Lea
  * and publictly available documentation, and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/done/Deque.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/done/Deque.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea and Josh Bloch with assistance from members of
  * JCP JSR-166 Expert Group and released to the public domain, as explained
- * at http://creativecommons.org/licenses/publicdomain
+ * at https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/done/NavigableMap.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/done/NavigableMap.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/done/NavigableSet.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/done/NavigableSet.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/done/PriorityQueue.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/done/PriorityQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, on the basis of public specifications of class
  * java.util.PriorityQueue by Josh Bloch, and released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain
+ * as explained at https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/done/Queue.java
+++ b/lib/java/backport-util-concurrent-2.1-src/src/edu/emory/mathcs/backport/java/util/done/Queue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/CASLoops.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/CASLoops.java
@@ -1,6 +1,6 @@
 /*
  * Written by Doug Lea and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 /*

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/CancelledFutureLoops.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/CancelledFutureLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 /*

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/CheckedLockLoops.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/CheckedLockLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /*
  * @test

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/CollectionWordLoops.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/CollectionWordLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 import edu.emory.mathcs.backport.java.util.*;
 import java.io.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/ConcurrentHashSet.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/ConcurrentHashSet.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 // A set wrapper over CHM for testing

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/ContextSwitchTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/ContextSwitchTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import edu.emory.mathcs.backport.java.util.concurrent.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/DequeBash.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/DequeBash.java
@@ -1,6 +1,6 @@
 /*
  * Written by Josh Bloch of Google Inc. and released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain.
+ * as explained at https://creativecommons.org/licenses/publicdomain.
  */
 
 import edu.emory.mathcs.backport.java.util.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/FinalLongTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/FinalLongTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 public class FinalLongTest {

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/Finals.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/Finals.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 public class Finals {

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/IntMapCheck.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/IntMapCheck.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /**
  * @test

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/IteratorLoops.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/IteratorLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import edu.emory.mathcs.backport.java.util.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/ListBash.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/ListBash.java
@@ -1,7 +1,7 @@
 /*
  * Written by Josh Bloch and Doug Lea with assistance from members of
  * JCP JSR-166 Expert Group and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 
 import edu.emory.mathcs.backport.java.util.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/LockLoops.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/LockLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /*
  * A simple test program. Feel free to play.

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/LoopHelpers.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/LoopHelpers.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /**
  * Misc utilities in JSR166 performance tests
@@ -19,7 +19,7 @@ class LoopHelpers {
 
     /**
      * generates 32 bit pseudo-random numbers.
-     * Adapted from http://www.snippets.org
+     * Adapted from https://www.snippets.org
      */
     public static int compute1(int x) {
         int lo = 16807 * (x & 0xFFFF);

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/MapCheck.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/MapCheck.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /**
  * @test

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/MapWordLoops.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/MapWordLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 import edu.emory.mathcs.backport.java.util.*;
 import java.io.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/Mutex.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/Mutex.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import java.util.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/NavigableMapCheck.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/NavigableMapCheck.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /**
  * @test

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/NavigableSetCheck.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/NavigableSetCheck.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /**
  * @test

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/NoopMutex.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/NoopMutex.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import edu.emory.mathcs.backport.java.util.concurrent.atomic.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/PriorityQueueSort.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/PriorityQueueSort.java
@@ -1,7 +1,7 @@
 /*
  * Written by Josh Bloch and Doug Lea with assistance from members of
  * JCP JSR-166 Expert Group and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 /*
  * @test

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/RLIBar.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/RLIBar.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 // Adapted from code that was in turn
 // Derived from SocketPerformanceTest.java - BugID: 4763450

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/RWCollection.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/RWCollection.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 import edu.emory.mathcs.backport.java.util.*;
 import edu.emory.mathcs.backport.java.util.concurrent.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/RWMap.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/RWMap.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 import edu.emory.mathcs.backport.java.util.*;
 import edu.emory.mathcs.backport.java.util.concurrent.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/ReadHoldingWriteLock.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/ReadHoldingWriteLock.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 import edu.emory.mathcs.backport.java.util.concurrent.locks.*;
 

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/SCollection.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/SCollection.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 import edu.emory.mathcs.backport.java.util.*;
 import edu.emory.mathcs.backport.java.util.concurrent.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/SMap.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/SMap.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 import edu.emory.mathcs.backport.java.util.*;
 import edu.emory.mathcs.backport.java.util.concurrent.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/SetBash.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/SetBash.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea and Josh Bloch with assistance from members of
  * JCP JSR-166 Expert Group and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 
 import java.util.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/Sync100M.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/Sync100M.java
@@ -3,7 +3,7 @@
 import edu.emory.mathcs.backport.java.util.concurrent.helpers.*;/*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 class Sync100M {

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/TSPExchangerTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/TSPExchangerTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea and Bill Scherer with assistance from members
  * of JCP JSR-166 Expert Group and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 
 import edu.emory.mathcs.backport.java.util.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/TimeUnitLoops.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/TimeUnitLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 import edu.emory.mathcs.backport.java.util.concurrent.*;
 import java.util.Random;

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/TimeoutLockLoops.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/TimeoutLockLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /*
  * @test %I% %E%

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/TimeoutMutexLoops.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/TimeoutMutexLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /*
  * @test

--- a/lib/java/backport-util-concurrent-2.1-src/test/loops/src/UncheckedLockLoops.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/loops/src/UncheckedLockLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /*
  * @test

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/LinkedListTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/LinkedListTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes, 
  * Pat Fisher, Mike Judd. 
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/AbstractQueueTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/AbstractQueueTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/AbstractQueuedSynchronizerTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/AbstractQueuedSynchronizerTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ArrayDequeTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ArrayDequeTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/AtomicIntegerFieldUpdaterTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/AtomicIntegerFieldUpdaterTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/AtomicLongFieldUpdaterTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/AtomicLongFieldUpdaterTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/AtomicReferenceFieldUpdaterTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/AtomicReferenceFieldUpdaterTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ConcurrentHashMapTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ConcurrentHashMapTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ConcurrentLinkedQueueTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ConcurrentLinkedQueueTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ConcurrentSkipListMapTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ConcurrentSkipListMapTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ConcurrentSkipListSetTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ConcurrentSkipListSetTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ConcurrentSkipListSubMapTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ConcurrentSkipListSubMapTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ConcurrentSkipListSubSetTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ConcurrentSkipListSubSetTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/CopyOnWriteArraySetTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/CopyOnWriteArraySetTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/EntryTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/EntryTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ExecutorCompletionServiceTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ExecutorCompletionServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ExecutorsTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ExecutorsTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/LinkedBlockingDequeTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/LinkedBlockingDequeTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/LinkedBlockingQueueTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/LinkedBlockingQueueTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/LinkedListTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/LinkedListTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/PriorityBlockingQueueTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/PriorityBlockingQueueTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/PriorityQueueTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/PriorityQueueTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ScheduledExecutorSubclassTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ScheduledExecutorSubclassTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ScheduledExecutorTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ScheduledExecutorTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/SemaphoreTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/SemaphoreTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/SynchronousQueueTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/SynchronousQueueTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ThreadPoolExecutorSubclassTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ThreadPoolExecutorSubclassTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ThreadPoolExecutorTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/ThreadPoolExecutorTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/TreeMapTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/TreeMapTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/TreeSetTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/TreeSetTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/TreeSubMapTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/TreeSubMapTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/TreeSubSetTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/TreeSubSetTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/AbstractExecutorServiceTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/AbstractExecutorServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/ArrayBlockingQueueTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/ArrayBlockingQueueTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/AtomicBooleanTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/AtomicBooleanTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/AtomicIntegerArrayTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/AtomicIntegerArrayTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/AtomicIntegerTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/AtomicIntegerTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/AtomicLongArrayTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/AtomicLongArrayTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/AtomicLongTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/AtomicLongTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/AtomicMarkableReferenceTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/AtomicMarkableReferenceTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/AtomicReferenceArrayTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/AtomicReferenceArrayTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/AtomicReferenceTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/AtomicReferenceTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/AtomicStampedReferenceTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/AtomicStampedReferenceTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/CopyOnWriteArrayListTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/CopyOnWriteArrayListTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/CountDownLatchTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/CountDownLatchTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/CyclicBarrierTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/CyclicBarrierTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/ExchangerTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/ExchangerTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/FutureTaskTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/FutureTaskTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/JSR166TestCase.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/JSR166TestCase.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/LockSupportTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/LockSupportTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/ReentrantLockTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/ReentrantLockTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/ReentrantReadWriteLockTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/ReentrantReadWriteLockTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/SystemTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/SystemTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/ThreadLocalTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/ThreadLocalTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/ThreadTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/ThreadTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/TimeUnitTest.java
+++ b/lib/java/backport-util-concurrent-2.1-src/test/tck/src/done/TimeUnitTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/DelayQueueTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/DelayQueueTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/LEGAL
+++ b/lib/java/backport-util-concurrent-2.2-src/LEGAL
@@ -1,5 +1,5 @@
 The backport-util-concurrent software has been released to the public domain, 
-as explained at: http://creativecommons.org/licenses/publicdomain.
+as explained at: https://creativecommons.org/licenses/publicdomain.
 
 Acknowledgements: backport-util-concurrent is based in large part on the public 
 domain sources from: 

--- a/lib/java/backport-util-concurrent-2.2-src/README.html
+++ b/lib/java/backport-util-concurrent-2.2-src/README.html
@@ -7,7 +7,7 @@
 
 <h1>backport-util-concurrent</h1>
 <p>Backport ot JSR 166 (java.util.concurrent) to Java 1.4</p>
-<p><a href="http://dcl.mathcs.emory.edu/util/backport-util-concurrent/">http://dcl.mathcs.emory.edu/util/backport-util-concurrent/</a></p>
+<p><a href="https://dcl.mathcs.emory.edu/util/backport-util-concurrent/">https://dcl.mathcs.emory.edu/util/backport-util-concurrent/</a></p>
 <hr class="hide">
 
 <h2>Overview</h2>
@@ -16,7 +16,7 @@
 This package is the backport of 
 <a href="http://gee.cs.oswego.edu/dl/concurrency-interest/">java.util.concurrent</a> API, 
 introduced in 
-<a href="http://java.sun.com/j2se/1.5.0/docs/guide/concurrency/overview.html">Java 5.0</a>,
+<a href="https://java.sun.com/j2se/1.5.0/docs/guide/concurrency/overview.html">Java 5.0</a>,
 to Java 1.4. The backport is based on public-domain sources from the
 <a href="http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/src/main/java/">
 JSR 166 CVS repository</a>, the
@@ -44,7 +44,7 @@ that should work with Java 5.0 simply by changing package names.
 
 <p>
 This software is released to the 
-<a href="http://creativecommons.org/licenses/publicdomain">public domain</a>,
+<a href="https://creativecommons.org/licenses/publicdomain">public domain</a>,
 in the spirit of the original code written by Doug Lea.
 The code can be used for any purpose, modified, and redistributed 
 without acknowledgment. No warranty is provided, either express or implied.
@@ -148,7 +148,7 @@ is presented below.
 <p>
 Package java.util.concurrent exploits new language features
 introduced in Java 5.0. In particular, most API classes are
-<a href="http://java.sun.com/j2se/1.5.0/docs/guide/language/generics.html">generic types</a>.
+<a href="https://java.sun.com/j2se/1.5.0/docs/guide/language/generics.html">generic types</a>.
 In the backport, they have been flattened to standard, non-generic 
 classes. Still, programs linked against the backport should compile 
 with Java 5.0 (after changing package names). Nevertheless, you may 
@@ -382,7 +382,7 @@ works fine.
 
 <p>
 
-Version 2.2 (Jun 4, 2006) [<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-2.2/backport-util-concurrent-2.2-changelog.html">CVS log</a>]
+Version 2.2 (Jun 4, 2006) [<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-2.2/backport-util-concurrent-2.2-changelog.html">CVS log</a>]
 
 <ul>
 <li>New features</li>
@@ -407,7 +407,7 @@ Version 2.2 (Jun 4, 2006) [<a href="http://www.mathcs.emory.edu/dcl/util/backpor
 </ul>
 
 
-Version 2.1 (Jan 28, 2006) [<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-2.1/backport-util-concurrent-2.1-changelog.html">CVS log</a>]
+Version 2.1 (Jan 28, 2006) [<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-2.1/backport-util-concurrent-2.1-changelog.html">CVS log</a>]
 <ul>
 <li>New features</li>
   <ul>
@@ -447,12 +447,12 @@ Version 2.1 (Jan 28, 2006) [<a href="http://www.mathcs.emory.edu/dcl/util/backpo
   </ul>
 </ul>
 
-Version 2.0_01 (Aug 3, 2005) [<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-2.0_01/backport-util-concurrent-2.0_01-changelog.html">CVS log</a>]
+Version 2.0_01 (Aug 3, 2005) [<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-2.0_01/backport-util-concurrent-2.0_01-changelog.html">CVS log</a>]
 <ul>
 <li>Compatibility fix: ConcurrentHashMap was no longer inheriting from java.util.AbstractMap, although it was in version 1.1_01. Now it does again.</li>
 <li>Licensing: new, public-domain implementation of PriorityQueue, and refactoring of backported AbstractMap so that it also contains only the public domain code.</li>
 </ul>
-Version 2.0 (Jul 6, 2005) [<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-2.0/backport-util-concurrent-2.0-changelog.html">CVS log</a>]
+Version 2.0 (Jul 6, 2005) [<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-2.0/backport-util-concurrent-2.0-changelog.html">CVS log</a>]
 <ul>
 <li>New features</li>
 <ul>
@@ -511,7 +511,7 @@ Version 2.0 (Jul 6, 2005) [<a href="http://www.mathcs.emory.edu/dcl/util/backpor
     [Collection,Map]WordLoops, CASLoops, and more</li>
 </ul>
 </ul>
-Version 1.1_01 (Feb 7, 2005) [<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-1.1_01/backport-util-concurrent-1.1_01-changelog.html">CVS log</a>]
+Version 1.1_01 (Feb 7, 2005) [<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-1.1_01/backport-util-concurrent-1.1_01-changelog.html">CVS log</a>]
 <ul>
 <li>Bugfix: race condition in the fair implementation of ReentrantLock 
 caused it to occassionally cause IllegalMonitorState exceptions. Non-fair
@@ -525,7 +525,7 @@ Thanks to Ramesh Nethi for reporting this bug and helping to track it down.</li>
 are included in the development source bundle.</li>
 </ul>
 
-Version 1.1 (Jan 21, 2005) [<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-1.1/backport-util-concurrent-1.1-changelog.html">CVS log</a>]
+Version 1.1 (Jan 21, 2005) [<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-1.1/backport-util-concurrent-1.1-changelog.html">CVS log</a>]
 <ul>
 <li>Bugfix: on Windows platforms with Java 1.4.2, the library
 were sometimes behaving as if timeouts were ignored or misinterpreted,
@@ -556,7 +556,7 @@ to tracking it down.</li>
 </li>
 </ul>
 
-Version 1.0_01 (Dec 28, 2004) [<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-1.0_01/backport-util-concurrent-1.0_01-changelog.html">CVS log</a>]
+Version 1.0_01 (Dec 28, 2004) [<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-1.0_01/backport-util-concurrent-1.0_01-changelog.html">CVS log</a>]
 <ul>
 <li>Feature: development source bundle with ant scripts allowing to build and
     test the distribution is now available for download.</li>
@@ -593,9 +593,9 @@ For more information:
 <LI>Consult the original 
     <a href="http://gee.cs.oswego.edu/dl/concurrency-interest/">
     java.util.concurrent</a> documentation and Java 5.0 
-    <a href="http://java.sun.com/j2se/1.5.0/docs/guide/concurrency/overview.html">Concurrency Utilities Overview</a></LI>
+    <a href="https://java.sun.com/j2se/1.5.0/docs/guide/concurrency/overview.html">Concurrency Utilities Overview</a></LI>
 
-<li>Check the <a href="http://dcl.mathcs.emory.edu/util/backport-util-concurrent/">project Web page</a> for updates.</li>
+<li>Check the <a href="https://dcl.mathcs.emory.edu/util/backport-util-concurrent/">project Web page</a> for updates.</li>
 
 <li>For questions, comments, and discussion, use the
 <a href="http://altair.cs.oswego.edu/mailman/listinfo/concurrency-interest">Concurrency-Interest 
@@ -608,7 +608,7 @@ e-mail directly to <a href="mailto:dawidk@mathcs.emory.edu">Dawid Kurzyniec</a>.
 </p>
 
 <hr>
-Copyright (C) 2004-2006 <a href="http://dcl.mathcs.emory.edu/">Distributed Computing Laboratory</a>, Emory University<br>
+Copyright (C) 2004-2006 <a href="https://dcl.mathcs.emory.edu/">Distributed Computing Laboratory</a>, Emory University<br>
 
 </body>
 </html>

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/AbstractCollection.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/AbstractCollection.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, based on public domain code written by Doug Lea
  * and publictly available documentation, and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/AbstractList.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/AbstractList.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, based on public domain code written by Doug Lea
  * and publictly available documentation, and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/AbstractMap.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/AbstractMap.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, based on public domain code written by Doug Lea
  * and publictly available documentation, and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/AbstractQueue.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/AbstractQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/AbstractSequentialList.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/AbstractSequentialList.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, based on public domain code written by Doug Lea
  * and publictly available documentation, and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/AbstractSet.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/AbstractSet.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, based on public domain code written by Doug Lea
  * and publictly available documentation, and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/ArrayDeque.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/ArrayDeque.java
@@ -1,6 +1,6 @@
 /*
  * Written by Josh Bloch of Google Inc. and released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain.
+ * as explained at https://creativecommons.org/licenses/publicdomain.
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/Arrays.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/Arrays.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, based on code written by Doug Lea with assistance
  * from members of JCP JSR-166 Expert Group. Released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain.
+ * as explained at https://creativecommons.org/licenses/publicdomain.
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/Collections.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/Collections.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, on the basis of public specifications and
  * public domain sources from JSR 166, and released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain.
+ * as explained at https://creativecommons.org/licenses/publicdomain.
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/Deque.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/Deque.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea and Josh Bloch with assistance from members of
  * JCP JSR-166 Expert Group and released to the public domain, as explained
- * at http://creativecommons.org/licenses/publicdomain
+ * at https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/NavigableMap.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/NavigableMap.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea and Josh Bloch with assistance from members of JCP
  * JSR-166 Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/NavigableSet.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/NavigableSet.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea and Josh Bloch with assistance from members of JCP
  * JSR-166 Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/PriorityQueue.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/PriorityQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, on the basis of public specifications of class
  * java.util.PriorityQueue by Josh Bloch, and released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain
+ * as explained at https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/Queue.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/Queue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/TreeMap.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/TreeMap.java
@@ -2,7 +2,7 @@
  * Written by Dawid Kurzyniec, on the basis of public specifications and
  * public domain sources from JSR 166 and the Doug Lea's collections package,
  * and released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain.
+ * as explained at https://creativecommons.org/licenses/publicdomain.
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/TreeSet.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/TreeSet.java
@@ -2,7 +2,7 @@
  * Written by Dawid Kurzyniec, on the basis of public specifications and
  * public domain sources from JSR 166 and the Doug Lea's collections package,
  * and released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain.
+ * as explained at https://creativecommons.org/licenses/publicdomain.
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/AbstractExecutorService.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/AbstractExecutorService.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ArrayBlockingQueue.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ArrayBlockingQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/BlockingDeque.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/BlockingDeque.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/BlockingQueue.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/BlockingQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/BrokenBarrierException.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/BrokenBarrierException.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/Callable.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/Callable.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/CancellationException.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/CancellationException.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/CompletionService.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/CompletionService.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentHashMap.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentHashMap.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentLinkedQueue.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentLinkedQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;
@@ -28,7 +28,7 @@ import java.util.NoSuchElementException;
  *
  * <p>This implementation employs an efficient &quot;wait-free&quot;
  * algorithm based on one described in <a
- * href="http://www.cs.rochester.edu/u/michael/PODC96.html"> Simple,
+ * href="https://www.cs.rochester.edu/u/michael/PODC96.html"> Simple,
  * Fast, and Practical Non-Blocking and Blocking Concurrent Queue
  * Algorithms</a> by Maged M. Michael and Michael L. Scott.
  *

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentMap.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentMap.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentNavigableMap.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentNavigableMap.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentSkipListMap.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentSkipListMap.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;
@@ -26,7 +26,7 @@ import java.util.SortedSet;
  * creation time, depending on which constructor is used.
  *
  * <p>This class implements a concurrent variant of <a
- * href="http://www.cs.umd.edu/~pugh/">SkipLists</a> providing
+ * href="https://www.cs.umd.edu/~pugh/">SkipLists</a> providing
  * expected average <i>log(n)</i> time cost for the
  * <tt>containsKey</tt>, <tt>get</tt>, <tt>put</tt> and
  * <tt>remove</tt> operations and their variants.  Insertion, removal,
@@ -102,10 +102,10 @@ public class ConcurrentSkipListMap extends AbstractMap
      * The base lists use a variant of the HM linked ordered set
      * algorithm. See Tim Harris, "A pragmatic implementation of
      * non-blocking linked lists"
-     * http://www.cl.cam.ac.uk/~tlh20/publications.html and Maged
+     * https://www.cl.cam.ac.uk/~tlh20/publications.html and Maged
      * Michael "High Performance Dynamic Lock-Free Hash Tables and
      * List-Based Sets"
-     * http://www.research.ibm.com/people/m/michael/pubs.htm.  The
+     * https://www.research.ibm.com/people/m/michael/pubs.htm.  The
      * basic idea in these lists is to mark the "next" pointers of
      * deleted nodes when deleting to avoid conflicts with concurrent
      * insertions, and when traversing to keep track of triples
@@ -277,8 +277,8 @@ public class ConcurrentSkipListMap extends AbstractMap
      * For explanation of algorithms sharing at least a couple of
      * features with this one, see Mikhail Fomitchev's thesis
      * (http://www.cs.yorku.ca/~mikhail/), Keir Fraser's thesis
-     * (http://www.cl.cam.ac.uk/users/kaf24/), and Hakan Sundell's
-     * thesis (http://www.cs.chalmers.se/~phs/).
+     * (https://www.cl.cam.ac.uk/users/kaf24/), and Hakan Sundell's
+     * thesis (https://www.chalmers.se/cse).
      *
      * Given the use of tree-like index nodes, you might wonder why
      * this doesn't use some kind of search tree instead, which would

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentSkipListSet.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentSkipListSet.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/CopyOnWriteArrayList.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/CopyOnWriteArrayList.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, on the basis of public specifications and
  * public domain sources from JSR 166, and released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain.
+ * as explained at https://creativecommons.org/licenses/publicdomain.
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/CyclicBarrier.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/CyclicBarrier.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/DelayQueue.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/DelayQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/Delayed.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/Delayed.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/Exchanger.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/Exchanger.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ExecutionException.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ExecutionException.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/Executor.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/Executor.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ExecutorCompletionService.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ExecutorCompletionService.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ExecutorService.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ExecutorService.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/Executors.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/Executors.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/Future.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/Future.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/LinkedBlockingDeque.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/LinkedBlockingDeque.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/LinkedBlockingQueue.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/LinkedBlockingQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/PriorityBlockingQueue.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/PriorityBlockingQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/RejectedExecutionException.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/RejectedExecutionException.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/RejectedExecutionHandler.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/RejectedExecutionHandler.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/RunnableFuture.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/RunnableFuture.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/RunnableScheduledFuture.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/RunnableScheduledFuture.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ScheduledExecutorService.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ScheduledExecutorService.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ScheduledFuture.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ScheduledFuture.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ScheduledThreadPoolExecutor.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ScheduledThreadPoolExecutor.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/Semaphore.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/Semaphore.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/SynchronousQueue.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/SynchronousQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ThreadFactory.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ThreadFactory.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ThreadPoolExecutor.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/ThreadPoolExecutor.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/TimeUnit.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/TimeUnit.java
@@ -1,7 +1,7 @@
 /*
   * Written by Doug Lea with assistance from members of JCP JSR-166
   * Expert Group and released to the public domain, as explained at
-  * http://creativecommons.org/licenses/publicdomain
+  * https://creativecommons.org/licenses/publicdomain
   */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/TimeoutException.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/TimeoutException.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicBoolean.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicBoolean.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicInteger.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicInteger.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicIntegerArray.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicIntegerArray.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicLong.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicLong.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicLongArray.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicLongArray.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicMarkableReference.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicMarkableReference.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicReference.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicReference.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicReferenceArray.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicReferenceArray.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicStampedReference.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicStampedReference.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/package.html
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/package.html
@@ -52,7 +52,7 @@ class Sequencer {
 
 <p>The memory effects for accesses and updates of atomics generally
 follow the rules for volatiles, as stated in <a
-href="http://java.sun.com/docs/books/jls/"> The Java Language
+href="https://java.sun.com/docs/books/jls/"> The Java Language
 Specification, Third Edition (17.4 Memory Model)</a>:
 
 <ul>

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/helpers/NanoTimer.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/helpers/NanoTimer.java
@@ -1,6 +1,6 @@
 /*
  * Written by Dawid Kurzyniec and released to the public domain, as explained
- * at http://creativecommons.org/licenses/publicdomain
+ * at https://creativecommons.org/licenses/publicdomain
  */
 package edu.emory.mathcs.backport.java.util.concurrent.helpers;
 

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/helpers/ThreadHelpers.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/helpers/ThreadHelpers.java
@@ -1,6 +1,6 @@
 /*
  * Written by Dawid Kurzyniec and released to the public domain, as explained
- * at http://creativecommons.org/licenses/publicdomain
+ * at https://creativecommons.org/licenses/publicdomain
  */
 package edu.emory.mathcs.backport.java.util.concurrent.helpers;
 

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/helpers/Utils.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/helpers/Utils.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, based on code written by Doug Lea with assistance
  * from members of JCP JSR-166 Expert Group. Released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain.
+ * as explained at https://creativecommons.org/licenses/publicdomain.
  *
  * Thanks to Craig Mattocks for suggesting to use <code>sun.misc.Perf</code>.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/Condition.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/Condition.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.locks;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/Lock.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/Lock.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.locks;
@@ -92,7 +92,7 @@ import edu.emory.mathcs.backport.java.util.concurrent.TimeUnit;
  *
  * <p>All {@code Lock} implementations <em>must</em> enforce the same
  * memory synchronization semantics as provided by the built-in monitor
- * lock, as described in <a href="http://java.sun.com/docs/books/jls/">
+ * lock, as described in <a href="https://java.sun.com/docs/books/jls/">
  * The Java Language Specification, Third Edition (17.4 Memory Model)</a>:
  * <ul>
  * <li>A successful {@code lock} operation has the same memory

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/ReadWriteLock.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/ReadWriteLock.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.locks;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/ReentrantLock.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/ReentrantLock.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.locks;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/ReentrantReadWriteLock.java
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/ReentrantReadWriteLock.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.locks;

--- a/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/package.html
+++ b/lib/java/backport-util-concurrent-2.2-src/src/edu/emory/mathcs/backport/java/util/concurrent/package.html
@@ -142,7 +142,7 @@ any updates since the iterator was created.
 <a name="MemoryVisibility">
 <h2> Memory Consistency Properties </h2>
 
-<a href="http://java.sun.com/docs/books/jls/third_edition/html/memory.html">
+<a href="https://java.sun.com/docs/books/jls/third_edition/html/memory.html">
 Chapter 17 of the Java Language Specification</a> defines the
 <i>happens-before</i> relation on memory operations such as reads and
 writes of shared variables.  The results of a write by one thread are

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/CASLoops.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/CASLoops.java
@@ -1,6 +1,6 @@
 /*
  * Written by Doug Lea and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 /*

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/CancelledFutureLoops.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/CancelledFutureLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 /*

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/CheckedLockLoops.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/CheckedLockLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /*
  * @test

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/CollectionWordLoops.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/CollectionWordLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 import java.io.*;
 import java.util.Collection;

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/ConcurrentHashSet.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/ConcurrentHashSet.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 // A set wrapper over CHM for testing

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/ContextSwitchTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/ContextSwitchTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import edu.emory.mathcs.backport.java.util.concurrent.*;

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/DequeBash.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/DequeBash.java
@@ -1,6 +1,6 @@
 /*
  * Written by Josh Bloch of Google Inc. and released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain.
+ * as explained at https://creativecommons.org/licenses/publicdomain.
  */
 
 import edu.emory.mathcs.backport.java.util.*;

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/FinalLongTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/FinalLongTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 public class FinalLongTest {

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/Finals.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/Finals.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 public class Finals {

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/IntMapCheck.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/IntMapCheck.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /**
  * @test

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/IteratorLoops.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/IteratorLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import edu.emory.mathcs.backport.java.util.*;

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/ListBash.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/ListBash.java
@@ -1,7 +1,7 @@
 /*
  * Written by Josh Bloch and Doug Lea with assistance from members of
  * JCP JSR-166 Expert Group and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 
 import edu.emory.mathcs.backport.java.util.*;

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/LockLoops.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/LockLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /*
  * A simple test program. Feel free to play.

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/LoopHelpers.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/LoopHelpers.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /**
  * Misc utilities in JSR166 performance tests
@@ -19,7 +19,7 @@ class LoopHelpers {
 
     /**
      * generates 32 bit pseudo-random numbers.
-     * Adapted from http://www.snippets.org
+     * Adapted from https://www.snippets.org
      */
     public static int compute1(int x) {
         int lo = 16807 * (x & 0xFFFF);

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/MapCheck.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/MapCheck.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /**
  * @test

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/MapWordLoops.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/MapWordLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 import edu.emory.mathcs.backport.java.util.*;
 import java.io.*;

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/Mutex.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/Mutex.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import edu.emory.mathcs.backport.java.util.concurrent.*;

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/NavigableMapCheck.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/NavigableMapCheck.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /**
  * @test

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/NavigableSetCheck.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/NavigableSetCheck.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /**
  * @test

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/NoopMutex.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/NoopMutex.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import edu.emory.mathcs.backport.java.util.concurrent.atomic.*;

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/PriorityQueueSort.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/PriorityQueueSort.java
@@ -1,7 +1,7 @@
 /*
  * Written by Josh Bloch and Doug Lea with assistance from members of
  * JCP JSR-166 Expert Group and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 /*
  * @test

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/RLIBar.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/RLIBar.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 // Adapted from code that was in turn
 // Derived from SocketPerformanceTest.java - BugID: 4763450

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/RWCollection.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/RWCollection.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 import edu.emory.mathcs.backport.java.util.*;
 import edu.emory.mathcs.backport.java.util.concurrent.*;

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/RWMap.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/RWMap.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 import edu.emory.mathcs.backport.java.util.*;
 import edu.emory.mathcs.backport.java.util.concurrent.*;

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/ReadHoldingWriteLock.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/ReadHoldingWriteLock.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 import edu.emory.mathcs.backport.java.util.concurrent.locks.*;
 

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/SCollection.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/SCollection.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 import edu.emory.mathcs.backport.java.util.*;
 import edu.emory.mathcs.backport.java.util.concurrent.*;

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/SMap.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/SMap.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 import edu.emory.mathcs.backport.java.util.*;
 import edu.emory.mathcs.backport.java.util.concurrent.*;

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/SetBash.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/SetBash.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea and Josh Bloch with assistance from members of
  * JCP JSR-166 Expert Group and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 
 import java.util.Set;

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/Sync100M.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/Sync100M.java
@@ -3,7 +3,7 @@
 import edu.emory.mathcs.backport.java.util.concurrent.helpers.*;/*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 class Sync100M {

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/TSPExchangerTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/TSPExchangerTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea and Bill Scherer with assistance from members
  * of JCP JSR-166 Expert Group and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 
 import edu.emory.mathcs.backport.java.util.*;

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/TimeUnitLoops.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/TimeUnitLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 import edu.emory.mathcs.backport.java.util.concurrent.*;
 import java.util.Random;

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/TimeoutLockLoops.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/TimeoutLockLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /*
  * @test %I% %E%

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/TimeoutMutexLoops.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/TimeoutMutexLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /*
  * @test

--- a/lib/java/backport-util-concurrent-2.2-src/test/loops/src/UncheckedLockLoops.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/loops/src/UncheckedLockLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /*
  * @test

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/LinkedListTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/LinkedListTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes, 
  * Pat Fisher, Mike Judd. 
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AbstractExecutorServiceTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AbstractExecutorServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AbstractQueueTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AbstractQueueTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AbstractQueuedSynchronizerTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AbstractQueuedSynchronizerTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ArrayBlockingQueueTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ArrayBlockingQueueTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ArrayDequeTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ArrayDequeTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AtomicBooleanTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AtomicBooleanTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AtomicIntegerArrayTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AtomicIntegerArrayTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AtomicIntegerFieldUpdaterTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AtomicIntegerFieldUpdaterTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AtomicIntegerTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AtomicIntegerTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AtomicLongArrayTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AtomicLongArrayTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AtomicLongFieldUpdaterTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AtomicLongFieldUpdaterTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AtomicLongTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AtomicLongTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AtomicMarkableReferenceTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AtomicMarkableReferenceTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AtomicReferenceArrayTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AtomicReferenceArrayTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AtomicReferenceFieldUpdaterTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AtomicReferenceFieldUpdaterTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AtomicReferenceTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AtomicReferenceTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AtomicStampedReferenceTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/AtomicStampedReferenceTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ConcurrentHashMapTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ConcurrentHashMapTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ConcurrentLinkedQueueTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ConcurrentLinkedQueueTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ConcurrentSkipListMapTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ConcurrentSkipListMapTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ConcurrentSkipListSetTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ConcurrentSkipListSetTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ConcurrentSkipListSubMapTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ConcurrentSkipListSubMapTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ConcurrentSkipListSubSetTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ConcurrentSkipListSubSetTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/CopyOnWriteArrayListTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/CopyOnWriteArrayListTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/CopyOnWriteArraySetTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/CopyOnWriteArraySetTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/CountDownLatchTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/CountDownLatchTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/CyclicBarrierTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/CyclicBarrierTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/DelayQueueTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/DelayQueueTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/EntryTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/EntryTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ExchangerTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ExchangerTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ExecutorCompletionServiceTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ExecutorCompletionServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ExecutorsTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ExecutorsTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/FutureTaskTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/FutureTaskTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/JSR166TestCase.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/JSR166TestCase.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/LinkedBlockingDequeTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/LinkedBlockingDequeTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/LinkedBlockingQueueTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/LinkedBlockingQueueTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/LinkedListTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/LinkedListTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/LockSupportTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/LockSupportTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/PriorityBlockingQueueTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/PriorityBlockingQueueTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/PriorityQueueTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/PriorityQueueTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ReentrantLockTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ReentrantLockTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ReentrantReadWriteLockTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ReentrantReadWriteLockTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ScheduledExecutorSubclassTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ScheduledExecutorSubclassTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ScheduledExecutorTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ScheduledExecutorTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/SemaphoreTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/SemaphoreTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/SynchronousQueueTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/SynchronousQueueTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/SystemTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/SystemTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ThreadLocalTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ThreadLocalTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ThreadPoolExecutorSubclassTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ThreadPoolExecutorSubclassTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ThreadPoolExecutorTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ThreadPoolExecutorTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ThreadTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/ThreadTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/TimeUnitTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/TimeUnitTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/TreeMapTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/TreeMapTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/TreeSetTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/TreeSetTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/TreeSubMapTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/TreeSubMapTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-2.2-src/test/tck/src/TreeSubSetTest.java
+++ b/lib/java/backport-util-concurrent-2.2-src/test/tck/src/TreeSubSetTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-3.1-src/LEGAL
+++ b/lib/java/backport-util-concurrent-3.1-src/LEGAL
@@ -1,5 +1,5 @@
 The backport-util-concurrent software has been released to the public domain, 
-as explained at: http://creativecommons.org/licenses/publicdomain.
+as explained at: https://creativecommons.org/licenses/publicdomain.
 
 Acknowledgements: backport-util-concurrent is based in large part on the public 
 domain sources from: 

--- a/lib/java/backport-util-concurrent-3.1-src/README.html
+++ b/lib/java/backport-util-concurrent-3.1-src/README.html
@@ -7,7 +7,7 @@
 
 <h1>backport-util-concurrent</h1>
 <p>Backport of JSR 166 (java.util.concurrent) to Java 1.2, 1.3, 1.4, and ... 5.0, and 6.0</p>
-<p><a href="http://dcl.mathcs.emory.edu/util/backport-util-concurrent/">http://dcl.mathcs.emory.edu/util/backport-util-concurrent/</a></p>
+<p><a href="https://dcl.mathcs.emory.edu/util/backport-util-concurrent/">https://dcl.mathcs.emory.edu/util/backport-util-concurrent/</a></p>
 <p>Release: 3.1, for Java 1.4</p>
 <hr class="hide">
 
@@ -17,7 +17,7 @@
 This package is the backport of 
 <a href="http://gee.cs.oswego.edu/dl/concurrency-interest/">java.util.concurrent</a> API,
 introduced in
-<a href="http://java.sun.com/j2se/1.5.0/docs/guide/concurrency/overview.html">Java 5.0</a>
+<a href="https://java.sun.com/j2se/1.5.0/docs/guide/concurrency/overview.html">Java 5.0</a>
 and further refined in Java 6.0,
 to older Java platforms. The backport is based on public-domain sources from the
 <a href="http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/src/main/java/">
@@ -74,7 +74,7 @@ FutureTask, scheduled tasks and executors, etc.)</li>
 
 <p>
 This software is released to the 
-<a href="http://creativecommons.org/licenses/publicdomain">public domain</a>,
+<a href="https://creativecommons.org/licenses/publicdomain">public domain</a>,
 in the spirit of the original code written by Doug Lea.
 The code can be used for any purpose, modified, and redistributed 
 without acknowledgment. No warranty is provided, either express or implied.
@@ -165,7 +165,7 @@ is presented below.
 <p>
 Package java.util.concurrent exploits new language features
 introduced in Java 5.0. In particular, most API classes are
-<a href="http://java.sun.com/j2se/1.5.0/docs/guide/language/generics.html">generic types</a>.
+<a href="https://java.sun.com/j2se/1.5.0/docs/guide/language/generics.html">generic types</a>.
 In the backport, they have been flattened to standard, non-generic 
 classes. Still, programs linked against the backport should compile 
 with Java 5.0 (after changing package names). Nevertheless, you may 
@@ -401,10 +401,10 @@ works fine.
 
 Version 3.1 (Jul 5, 2006)<br>
 SVN logs: 
-[<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-3.1/backport-util-concurrent-3.1-changelog.html">Java 1.4</a>, 
-<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-3.1/backport-util-concurrent-Java12-3.1-changelog.html">Java 1.2 - 1.3</a>,
-<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-3.1/backport-util-concurrent-Java50-3.1-changelog.html">Java 5.0</a>, 
-<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-3.1/backport-util-concurrent-Java60-3.1-changelog.html">Java 6.0</a>]
+[<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-3.1/backport-util-concurrent-3.1-changelog.html">Java 1.4</a>, 
+<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-3.1/backport-util-concurrent-Java12-3.1-changelog.html">Java 1.2 - 1.3</a>,
+<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-3.1/backport-util-concurrent-Java50-3.1-changelog.html">Java 5.0</a>, 
+<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-3.1/backport-util-concurrent-Java60-3.1-changelog.html">Java 6.0</a>]
 
 <ul>
 <li>New features</li>
@@ -422,9 +422,9 @@ SVN logs:
 
 Version 3.0 (Nov 11, 2006)<br>
 SVN logs: 
-[<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-3.0/backport-util-concurrent-3.0-changelog.html">Java 1.4</a>, 
-<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-3.0/backport-util-concurrent-Java50-3.0-changelog.html">Java 5.0</a>, 
-<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-3.0/backport-util-concurrent-Java12-3.0-changelog.html">Java 1.2 - 1.3</a>]
+[<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-3.0/backport-util-concurrent-3.0-changelog.html">Java 1.4</a>, 
+<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-3.0/backport-util-concurrent-Java50-3.0-changelog.html">Java 5.0</a>, 
+<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-3.0/backport-util-concurrent-Java12-3.0-changelog.html">Java 1.2 - 1.3</a>]
 
 <ul>
 <li>New features</li>
@@ -444,7 +444,7 @@ SVN logs:
   </ul>
 </ul>
 
-Version 2.2 (Jun 4, 2006) [<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-2.2/backport-util-concurrent-2.2-changelog.html">CVS log</a>]
+Version 2.2 (Jun 4, 2006) [<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-2.2/backport-util-concurrent-2.2-changelog.html">CVS log</a>]
 
 <ul>
 <li>New features</li>
@@ -468,7 +468,7 @@ Version 2.2 (Jun 4, 2006) [<a href="http://www.mathcs.emory.edu/dcl/util/backpor
   </ul>
 </ul>
 
-Version 2.1 (Jan 28, 2006) [<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-2.1/backport-util-concurrent-2.1-changelog.html">CVS log</a>]
+Version 2.1 (Jan 28, 2006) [<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-2.1/backport-util-concurrent-2.1-changelog.html">CVS log</a>]
 <ul>
 <li>New features</li>
   <ul>
@@ -508,12 +508,12 @@ Version 2.1 (Jan 28, 2006) [<a href="http://www.mathcs.emory.edu/dcl/util/backpo
   </ul>
 </ul>
 
-Version 2.0_01 (Aug 3, 2005) [<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-2.0_01/backport-util-concurrent-2.0_01-changelog.html">CVS log</a>]
+Version 2.0_01 (Aug 3, 2005) [<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-2.0_01/backport-util-concurrent-2.0_01-changelog.html">CVS log</a>]
 <ul>
 <li>Compatibility fix: ConcurrentHashMap was no longer inheriting from java.util.AbstractMap, although it was in version 1.1_01. Now it does again.</li>
 <li>Licensing: new, public-domain implementation of PriorityQueue, and refactoring of backported AbstractMap so that it also contains only the public domain code.</li>
 </ul>
-Version 2.0 (Jul 6, 2005) [<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-2.0/backport-util-concurrent-2.0-changelog.html">CVS log</a>]
+Version 2.0 (Jul 6, 2005) [<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-2.0/backport-util-concurrent-2.0-changelog.html">CVS log</a>]
 <ul>
 <li>New features</li>
 <ul>
@@ -572,7 +572,7 @@ Version 2.0 (Jul 6, 2005) [<a href="http://www.mathcs.emory.edu/dcl/util/backpor
     [Collection,Map]WordLoops, CASLoops, and more</li>
 </ul>
 </ul>
-Version 1.1_01 (Feb 7, 2005) [<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-1.1_01/backport-util-concurrent-1.1_01-changelog.html">CVS log</a>]
+Version 1.1_01 (Feb 7, 2005) [<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-1.1_01/backport-util-concurrent-1.1_01-changelog.html">CVS log</a>]
 <ul>
 <li>Bugfix: race condition in the fair implementation of ReentrantLock 
 caused it to occassionally cause IllegalMonitorState exceptions. Non-fair
@@ -586,7 +586,7 @@ Thanks to Ramesh Nethi for reporting this bug and helping to track it down.</li>
 are included in the development source bundle.</li>
 </ul>
 
-Version 1.1 (Jan 21, 2005) [<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-1.1/backport-util-concurrent-1.1-changelog.html">CVS log</a>]
+Version 1.1 (Jan 21, 2005) [<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-1.1/backport-util-concurrent-1.1-changelog.html">CVS log</a>]
 <ul>
 <li>Bugfix: on Windows platforms with Java 1.4.2, the library
 were sometimes behaving as if timeouts were ignored or misinterpreted,
@@ -617,7 +617,7 @@ to tracking it down.</li>
 </li>
 </ul>
 
-Version 1.0_01 (Dec 28, 2004) [<a href="http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-1.0_01/backport-util-concurrent-1.0_01-changelog.html">CVS log</a>]
+Version 1.0_01 (Dec 28, 2004) [<a href="https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-1.0_01/backport-util-concurrent-1.0_01-changelog.html">CVS log</a>]
 <ul>
 <li>Feature: development source bundle with ant scripts allowing to build and
     test the distribution is now available for download.</li>
@@ -654,9 +654,9 @@ For more information:
 <LI>Consult the original 
     <a href="http://gee.cs.oswego.edu/dl/concurrency-interest/">
     java.util.concurrent</a> documentation and Java 5.0 
-    <a href="http://java.sun.com/j2se/1.5.0/docs/guide/concurrency/overview.html">Concurrency Utilities Overview</a></LI>
+    <a href="https://java.sun.com/j2se/1.5.0/docs/guide/concurrency/overview.html">Concurrency Utilities Overview</a></LI>
 
-<li>Check the <a href="http://dcl.mathcs.emory.edu/util/backport-util-concurrent/">project Web page</a> for updates.</li>
+<li>Check the <a href="https://dcl.mathcs.emory.edu/util/backport-util-concurrent/">project Web page</a> for updates.</li>
 
 <li>For questions, comments, and discussion, use the
 <a href="http://altair.cs.oswego.edu/mailman/listinfo/concurrency-interest">Concurrency-Interest 
@@ -668,8 +668,8 @@ You may also send an e-mail directly to dawid.kurzyniec at gmail.com.</a>.</li>
 </p>
 
 <hr>
-<a href="http://dcl.mathcs.emory.edu/">Distributed Computing Laboratory</a>, Emory University<br>
-<a href="http://google.com/">Google, Inc.</a><br>
+<a href="https://dcl.mathcs.emory.edu/">Distributed Computing Laboratory</a>, Emory University<br>
+<a href="https://google.com/">Google, Inc.</a><br>
 
 </body>
 </html>

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/AbstractCollection.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/AbstractCollection.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, based on public domain code written by Doug Lea
  * and publictly available documentation, and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/AbstractList.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/AbstractList.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, based on public domain code written by Doug Lea
  * and publictly available documentation, and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/AbstractMap.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/AbstractMap.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, based on public domain code written by Doug Lea
  * and publictly available documentation, and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/AbstractQueue.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/AbstractQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/AbstractSequentialList.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/AbstractSequentialList.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, based on public domain code written by Doug Lea
  * and publictly available documentation, and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/AbstractSet.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/AbstractSet.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, based on public domain code written by Doug Lea
  * and publictly available documentation, and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/ArrayDeque.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/ArrayDeque.java
@@ -1,6 +1,6 @@
 /*
  * Written by Josh Bloch of Google Inc. and released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain.
+ * as explained at https://creativecommons.org/licenses/publicdomain.
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/Arrays.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/Arrays.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, based on code written by Doug Lea with assistance
  * from members of JCP JSR-166 Expert Group. Released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain.
+ * as explained at https://creativecommons.org/licenses/publicdomain.
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/Collections.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/Collections.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, on the basis of public specifications and
  * public domain sources from JSR 166, and released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain.
+ * as explained at https://creativecommons.org/licenses/publicdomain.
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/Deque.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/Deque.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea and Josh Bloch with assistance from members of
  * JCP JSR-166 Expert Group and released to the public domain, as explained
- * at http://creativecommons.org/licenses/publicdomain
+ * at https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/NavigableMap.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/NavigableMap.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea and Josh Bloch with assistance from members of JCP
  * JSR-166 Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/NavigableSet.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/NavigableSet.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea and Josh Bloch with assistance from members of JCP
  * JSR-166 Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/PriorityQueue.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/PriorityQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, on the basis of public specifications of class
  * java.util.PriorityQueue by Josh Bloch, and released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain
+ * as explained at https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/Queue.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/Queue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/TreeMap.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/TreeMap.java
@@ -2,7 +2,7 @@
  * Written by Dawid Kurzyniec, on the basis of public specifications and
  * public domain sources from JSR 166 and the Doug Lea's collections package,
  * and released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain.
+ * as explained at https://creativecommons.org/licenses/publicdomain.
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/TreeSet.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/TreeSet.java
@@ -2,7 +2,7 @@
  * Written by Dawid Kurzyniec, on the basis of public specifications and
  * public domain sources from JSR 166 and the Doug Lea's collections package,
  * and released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain.
+ * as explained at https://creativecommons.org/licenses/publicdomain.
  */
 
 package edu.emory.mathcs.backport.java.util;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ArrayBlockingQueue.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ArrayBlockingQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/BlockingDeque.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/BlockingDeque.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/BlockingQueue.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/BlockingQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/BrokenBarrierException.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/BrokenBarrierException.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/Callable.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/Callable.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/CancellationException.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/CancellationException.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/CompletionService.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/CompletionService.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentHashMap.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentHashMap.java
@@ -1,7 +1,7 @@
  /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentLinkedQueue.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentLinkedQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;
@@ -27,7 +27,7 @@ import java.util.NoSuchElementException;
  *
  * <p>This implementation employs an efficient &quot;wait-free&quot;
  * algorithm based on one described in <a
- * href="http://www.cs.rochester.edu/u/michael/PODC96.html"> Simple,
+ * href="https://www.cs.rochester.edu/u/michael/PODC96.html"> Simple,
  * Fast, and Practical Non-Blocking and Blocking Concurrent Queue
  * Algorithms</a> by Maged M. Michael and Michael L. Scott.
  *

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentMap.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentMap.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentNavigableMap.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentNavigableMap.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentSkipListMap.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentSkipListMap.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;
@@ -26,7 +26,7 @@ import java.util.List;
  * creation time, depending on which constructor is used.
  *
  * <p>This class implements a concurrent variant of <a
- * href="http://www.cs.umd.edu/~pugh/">SkipLists</a> providing
+ * href="https://www.cs.umd.edu/~pugh/">SkipLists</a> providing
  * expected average <i>log(n)</i> time cost for the
  * <tt>containsKey</tt>, <tt>get</tt>, <tt>put</tt> and
  * <tt>remove</tt> operations and their variants.  Insertion, removal,
@@ -102,10 +102,10 @@ public class ConcurrentSkipListMap extends AbstractMap
      * The base lists use a variant of the HM linked ordered set
      * algorithm. See Tim Harris, "A pragmatic implementation of
      * non-blocking linked lists"
-     * http://www.cl.cam.ac.uk/~tlh20/publications.html and Maged
+     * https://www.cl.cam.ac.uk/~tlh20/publications.html and Maged
      * Michael "High Performance Dynamic Lock-Free Hash Tables and
      * List-Based Sets"
-     * http://www.research.ibm.com/people/m/michael/pubs.htm.  The
+     * https://www.research.ibm.com/people/m/michael/pubs.htm.  The
      * basic idea in these lists is to mark the "next" pointers of
      * deleted nodes when deleting to avoid conflicts with concurrent
      * insertions, and when traversing to keep track of triples
@@ -277,8 +277,8 @@ public class ConcurrentSkipListMap extends AbstractMap
      * For explanation of algorithms sharing at least a couple of
      * features with this one, see Mikhail Fomitchev's thesis
      * (http://www.cs.yorku.ca/~mikhail/), Keir Fraser's thesis
-     * (http://www.cl.cam.ac.uk/users/kaf24/), and Hakan Sundell's
-     * thesis (http://www.cs.chalmers.se/~phs/).
+     * (https://www.cl.cam.ac.uk/users/kaf24/), and Hakan Sundell's
+     * thesis (https://www.chalmers.se/cse).
      *
      * Given the use of tree-like index nodes, you might wonder why
      * this doesn't use some kind of search tree instead, which would

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentSkipListSet.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ConcurrentSkipListSet.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/CopyOnWriteArrayList.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/CopyOnWriteArrayList.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, on the basis of public specifications and
  * public domain sources from JSR 166, and released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain.
+ * as explained at https://creativecommons.org/licenses/publicdomain.
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/CopyOnWriteArraySet.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/CopyOnWriteArraySet.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/CyclicBarrier.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/CyclicBarrier.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/DelayQueue.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/DelayQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/Delayed.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/Delayed.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/Exchanger.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/Exchanger.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ExecutionException.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ExecutionException.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ExecutorCompletionService.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ExecutorCompletionService.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ExecutorService.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ExecutorService.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/Future.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/Future.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/LinkedBlockingDeque.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/LinkedBlockingDeque.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/LinkedBlockingQueue.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/LinkedBlockingQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/PriorityBlockingQueue.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/PriorityBlockingQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/RejectedExecutionException.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/RejectedExecutionException.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/RejectedExecutionHandler.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/RejectedExecutionHandler.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/RunnableFuture.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/RunnableFuture.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/RunnableScheduledFuture.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/RunnableScheduledFuture.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ScheduledExecutorService.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ScheduledExecutorService.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ScheduledFuture.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ScheduledFuture.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ScheduledThreadPoolExecutor.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ScheduledThreadPoolExecutor.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/Semaphore.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/Semaphore.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/SynchronousQueue.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/SynchronousQueue.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ThreadFactory.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/ThreadFactory.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/TimeUnit.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/TimeUnit.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/TimeoutException.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/TimeoutException.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicBoolean.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicBoolean.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicInteger.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicInteger.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicIntegerArray.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicIntegerArray.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicLong.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicLong.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicLongArray.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicLongArray.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicMarkableReference.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicMarkableReference.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicReference.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicReference.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicReferenceArray.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicReferenceArray.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicStampedReference.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/AtomicStampedReference.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.atomic;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/package.html
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/atomic/package.html
@@ -55,7 +55,7 @@ class Sequencer {
 
 <p>The memory effects for accesses and updates of atomics generally
 follow the rules for volatiles, as stated in <a
-href="http://java.sun.com/docs/books/jls/"> The Java Language
+href="https://java.sun.com/docs/books/jls/"> The Java Language
 Specification, Third Edition (17.4 Memory Model)</a>:
 
 <ul>

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/AbstractExecutorService.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/AbstractExecutorService.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/Executor.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/Executor.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/Executors.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/Executors.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/ThreadPoolExecutor.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/done/ThreadPoolExecutor.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/helpers/NanoTimer.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/helpers/NanoTimer.java
@@ -1,6 +1,6 @@
 /*
  * Written by Dawid Kurzyniec and released to the public domain, as explained
- * at http://creativecommons.org/licenses/publicdomain
+ * at https://creativecommons.org/licenses/publicdomain
  */
 package edu.emory.mathcs.backport.java.util.concurrent.helpers;
 

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/helpers/ThreadHelpers.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/helpers/ThreadHelpers.java
@@ -1,6 +1,6 @@
 /*
  * Written by Dawid Kurzyniec and released to the public domain, as explained
- * at http://creativecommons.org/licenses/publicdomain
+ * at https://creativecommons.org/licenses/publicdomain
  */
 package edu.emory.mathcs.backport.java.util.concurrent.helpers;
 

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/helpers/Utils.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/helpers/Utils.java
@@ -1,7 +1,7 @@
 /*
  * Written by Dawid Kurzyniec, based on code written by Doug Lea with assistance
  * from members of JCP JSR-166 Expert Group. Released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain.
+ * as explained at https://creativecommons.org/licenses/publicdomain.
  *
  * Thanks to Craig Mattocks for suggesting to use <code>sun.misc.Perf</code>.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/done/Condition.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/done/Condition.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.locks;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/done/Lock.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/done/Lock.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.locks;
@@ -92,7 +92,7 @@ import edu.emory.mathcs.backport.java.util.concurrent.TimeUnit;
  *
  * <p>All {@code Lock} implementations <em>must</em> enforce the same
  * memory synchronization semantics as provided by the built-in monitor
- * lock, as described in <a href="http://java.sun.com/docs/books/jls/">
+ * lock, as described in <a href="https://java.sun.com/docs/books/jls/">
  * The Java Language Specification, Third Edition (17.4 Memory Model)</a>:
  * <ul>
  * <li>A successful {@code lock} operation has the same memory

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/done/ReadWriteLock.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/done/ReadWriteLock.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.locks;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/done/ReentrantLock.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/done/ReentrantLock.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.locks;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/done/ReentrantReadWriteLock.java
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/locks/done/ReentrantReadWriteLock.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 package edu.emory.mathcs.backport.java.util.concurrent.locks;

--- a/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/package.html
+++ b/lib/java/backport-util-concurrent-3.1-src/src/edu/emory/mathcs/backport/java/util/concurrent/package.html
@@ -142,7 +142,7 @@ any updates since the iterator was created.
 <a name="MemoryVisibility">
 <h2> Memory Consistency Properties </h2>
 
-<a href="http://java.sun.com/docs/books/jls/third_edition/html/memory.html">
+<a href="https://java.sun.com/docs/books/jls/third_edition/html/memory.html">
 Chapter 17 of the Java Language Specification</a> defines the
 <i>happens-before</i> relation on memory operations such as reads and
 writes of shared variables.  The results of a write by one thread are

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/CASLoops.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/CASLoops.java
@@ -1,6 +1,6 @@
 /*
  * Written by Doug Lea and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 /*

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/CancelledFutureLoops.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/CancelledFutureLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 /*

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/CheckedLockLoops.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/CheckedLockLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /*
  * @test

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/CollectionWordLoops.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/CollectionWordLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 import java.io.*;
 import java.util.Collection;

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/ConcurrentHashSet.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/ConcurrentHashSet.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 // A set wrapper over CHM for testing

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/ContextSwitchTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/ContextSwitchTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import edu.emory.mathcs.backport.java.util.concurrent.*;

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/DequeBash.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/DequeBash.java
@@ -1,6 +1,6 @@
 /*
  * Written by Josh Bloch of Google Inc. and released to the public domain,
- * as explained at http://creativecommons.org/licenses/publicdomain.
+ * as explained at https://creativecommons.org/licenses/publicdomain.
  */
 
 import edu.emory.mathcs.backport.java.util.*;

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/FinalLongTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/FinalLongTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 public class FinalLongTest {

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/Finals.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/Finals.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 public class Finals {

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/IntMapCheck.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/IntMapCheck.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /**
  * @test

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/IteratorLoops.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/IteratorLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import edu.emory.mathcs.backport.java.util.*;

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/ListBash.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/ListBash.java
@@ -1,7 +1,7 @@
 /*
  * Written by Josh Bloch and Doug Lea with assistance from members of
  * JCP JSR-166 Expert Group and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 
 import edu.emory.mathcs.backport.java.util.*;

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/LockLoops.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/LockLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /*
  * A simple test program. Feel free to play.

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/LoopHelpers.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/LoopHelpers.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /**
  * Misc utilities in JSR166 performance tests
@@ -19,7 +19,7 @@ class LoopHelpers {
 
     /**
      * generates 32 bit pseudo-random numbers.
-     * Adapted from http://www.snippets.org
+     * Adapted from https://www.snippets.org
      */
     public static int compute1(int x) {
         int lo = 16807 * (x & 0xFFFF);

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/MapCheck.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/MapCheck.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /**
  * @test

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/MapWordLoops.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/MapWordLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 import edu.emory.mathcs.backport.java.util.*;
 import java.io.*;

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/Mutex.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/Mutex.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import edu.emory.mathcs.backport.java.util.concurrent.*;

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/NavigableMapCheck.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/NavigableMapCheck.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /**
  * @test

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/NavigableSetCheck.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/NavigableSetCheck.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /**
  * @test

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/NoopMutex.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/NoopMutex.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import edu.emory.mathcs.backport.java.util.concurrent.atomic.*;

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/PriorityQueueSort.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/PriorityQueueSort.java
@@ -1,7 +1,7 @@
 /*
  * Written by Josh Bloch and Doug Lea with assistance from members of
  * JCP JSR-166 Expert Group and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 /*
  * @test

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/RLIBar.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/RLIBar.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 // Adapted from code that was in turn
 // Derived from SocketPerformanceTest.java - BugID: 4763450

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/RWCollection.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/RWCollection.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 import edu.emory.mathcs.backport.java.util.*;
 import edu.emory.mathcs.backport.java.util.concurrent.*;

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/RWMap.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/RWMap.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 import edu.emory.mathcs.backport.java.util.*;
 import edu.emory.mathcs.backport.java.util.concurrent.*;

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/ReadHoldingWriteLock.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/ReadHoldingWriteLock.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 import edu.emory.mathcs.backport.java.util.concurrent.locks.*;
 

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/SCollection.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/SCollection.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 import edu.emory.mathcs.backport.java.util.*;
 import edu.emory.mathcs.backport.java.util.concurrent.*;

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/SMap.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/SMap.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 import edu.emory.mathcs.backport.java.util.*;
 import edu.emory.mathcs.backport.java.util.concurrent.*;

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/SetBash.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/SetBash.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea and Josh Bloch with assistance from members of
  * JCP JSR-166 Expert Group and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 
 import java.util.Set;

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/Sync100M.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/Sync100M.java
@@ -3,7 +3,7 @@
 import edu.emory.mathcs.backport.java.util.concurrent.helpers.*;/*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 class Sync100M {

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/TSPExchangerTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/TSPExchangerTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea and Bill Scherer with assistance from members
  * of JCP JSR-166 Expert Group and released to the public domain, as
- * explained at http://creativecommons.org/licenses/publicdomain
+ * explained at https://creativecommons.org/licenses/publicdomain
  */
 
 import edu.emory.mathcs.backport.java.util.*;

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/TimeUnitLoops.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/TimeUnitLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 import edu.emory.mathcs.backport.java.util.concurrent.*;
 import java.util.Random;

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/TimeoutLockLoops.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/TimeoutLockLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /*
  * @test %I% %E%

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/TimeoutMutexLoops.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/TimeoutMutexLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /*
  * @test

--- a/lib/java/backport-util-concurrent-3.1-src/test/loops/src/UncheckedLockLoops.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/loops/src/UncheckedLockLoops.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 /*
  * @test

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/LinkedListTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/LinkedListTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes, 
  * Pat Fisher, Mike Judd. 
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AbstractQueueTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AbstractQueueTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AbstractQueuedSynchronizerTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AbstractQueuedSynchronizerTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ArrayBlockingQueueTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ArrayBlockingQueueTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ArrayDequeTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ArrayDequeTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AtomicBooleanTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AtomicBooleanTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AtomicIntegerArrayTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AtomicIntegerArrayTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AtomicIntegerFieldUpdaterTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AtomicIntegerFieldUpdaterTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AtomicIntegerTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AtomicIntegerTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AtomicLongArrayTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AtomicLongArrayTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AtomicLongFieldUpdaterTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AtomicLongFieldUpdaterTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AtomicLongTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AtomicLongTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AtomicMarkableReferenceTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AtomicMarkableReferenceTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AtomicReferenceArrayTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AtomicReferenceArrayTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AtomicReferenceFieldUpdaterTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AtomicReferenceFieldUpdaterTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AtomicReferenceTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AtomicReferenceTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AtomicStampedReferenceTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/AtomicStampedReferenceTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ConcurrentHashMapTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ConcurrentHashMapTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ConcurrentLinkedQueueTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ConcurrentLinkedQueueTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ConcurrentSkipListMapTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ConcurrentSkipListMapTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ConcurrentSkipListSetTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ConcurrentSkipListSetTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ConcurrentSkipListSubMapTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ConcurrentSkipListSubMapTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ConcurrentSkipListSubSetTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ConcurrentSkipListSubSetTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/CopyOnWriteArrayListTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/CopyOnWriteArrayListTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/CopyOnWriteArraySetTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/CopyOnWriteArraySetTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/CountDownLatchTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/CountDownLatchTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/CyclicBarrierTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/CyclicBarrierTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/DelayQueueTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/DelayQueueTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/EntryTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/EntryTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ExchangerTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ExchangerTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ExecutorCompletionServiceTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ExecutorCompletionServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ExecutorsTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ExecutorsTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/FutureTaskTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/FutureTaskTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/JSR166TestCase.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/JSR166TestCase.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/LinkedBlockingDequeTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/LinkedBlockingDequeTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/LinkedBlockingQueueTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/LinkedBlockingQueueTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/LinkedListTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/LinkedListTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/LockSupportTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/LockSupportTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/PriorityBlockingQueueTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/PriorityBlockingQueueTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/PriorityQueueTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/PriorityQueueTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ScheduledExecutorSubclassTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ScheduledExecutorSubclassTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ScheduledExecutorTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ScheduledExecutorTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/SemaphoreTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/SemaphoreTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/SynchronousQueueTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/SynchronousQueueTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/SystemTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/SystemTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ThreadLocalTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ThreadLocalTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ThreadPoolExecutorSubclassTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ThreadPoolExecutorSubclassTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ThreadPoolExecutorTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ThreadPoolExecutorTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ThreadTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/ThreadTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/TimeUnitTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/TimeUnitTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/TreeMapTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/TreeMapTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/TreeSetTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/TreeSetTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/TreeSubMapTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/TreeSubMapTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/TreeSubSetTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/TreeSubSetTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 import junit.framework.*;

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/done/AbstractExecutorServiceTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/done/AbstractExecutorServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/done/ReentrantLockTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/done/ReentrantLockTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/lib/java/backport-util-concurrent-3.1-src/test/tck/src/done/ReentrantReadWriteLockTest.java
+++ b/lib/java/backport-util-concurrent-3.1-src/test/tck/src/done/ReentrantReadWriteLockTest.java
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/src/Spring/Spring.Threading/Threading/Collections/Generic/PriorityBlockingQueue.cs
+++ b/src/Spring/Spring.Threading/Threading/Collections/Generic/PriorityBlockingQueue.cs
@@ -1,7 +1,7 @@
 ﻿/*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 #region License

--- a/src/Spring/Spring.Threading/Threading/ForkJoin/FJTaskRunner.cs
+++ b/src/Spring/Spring.Threading/Threading/ForkJoin/FJTaskRunner.cs
@@ -1,6 +1,6 @@
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -59,9 +59,9 @@ namespace Spring.Threading.ForkJoin
 	/// <p>
 	/// The algorithms are minor variants of those used
 	/// in <A href="http://supertech.lcs.mit.edu/cilk/"> Cilk</A> and
-	/// <A href="http://www.cs.utexas.edu/users/hood/"> Hood</A>, and
+	/// <A href="https://www.cs.utexas.edu/users/hood/"> Hood</A>, and
 	/// to a lesser extent 
-	/// <A href="http://www.cs.uga.edu/~dkl/filaments/dist.html"> Filaments</A>,
+	/// <A href="http://cobweb.cs.uga.edu/~dkl/filaments/dist.html"> Filaments</A>,
 	/// but are adapted to work in Java.
 	/// </p>
 	/// <p>

--- a/src/Spring/Spring.Threading/Threading/WaitFreeQueue.cs
+++ b/src/Spring/Spring.Threading/Threading/WaitFreeQueue.cs
@@ -1,6 +1,6 @@
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ namespace Spring.Threading
 	/// extremely wasteful.  </p>
 	/// <p>
 	/// This class is adapted from the algorithm described in <a
-	/// href="http://www.cs.rochester.edu/u/michael/PODC96.html"> Simple,
+	/// href="https://www.cs.rochester.edu/u/michael/PODC96.html"> Simple,
 	/// Fast, and Practical Non-Blocking and Blocking Concurrent Queue
 	/// Algorithms</a> by Maged M. Michael and Michael L. Scott.  This
 	/// implementation is not strictly wait-free since it relies on locking

--- a/test/Spring/Spring.Threading.Loops/Arrays.cs
+++ b/test/Spring/Spring.Threading.Loops/Arrays.cs
@@ -1,7 +1,7 @@
 ﻿/*
 * Written by Dawid Kurzyniec, based on code written by Doug Lea with assistance
 * from members of JCP JSR-166 Expert Group. Released to the public domain,
-* as explained at http://creativecommons.org/licenses/publicdomain.
+* as explained at https://creativecommons.org/licenses/publicdomain.
 */
 using System;
 namespace edu.emory.mathcs.backport.java.util

--- a/test/Spring/Spring.Threading.Loops/CASLoops.cs
+++ b/test/Spring/Spring.Threading.Loops/CASLoops.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * Written by Doug Lea and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 /*

--- a/test/Spring/Spring.Threading.Loops/INanoTimer.cs
+++ b/test/Spring/Spring.Threading.Loops/INanoTimer.cs
@@ -1,6 +1,6 @@
 ﻿/*
 * Written by Dawid Kurzyniec and released to the public domain, as explained
-* at http://creativecommons.org/licenses/publicdomain
+* at https://creativecommons.org/licenses/publicdomain
 */
 using System;
 namespace edu.emory.mathcs.backport.java.util.concurrent.helpers

--- a/test/Spring/Spring.Threading.Loops/LoopHelpers.cs
+++ b/test/Spring/Spring.Threading.Loops/LoopHelpers.cs
@@ -1,7 +1,7 @@
 ﻿/*
 * Written by Doug Lea with assistance from members of JCP JSR-166
 * Expert Group and released to the public domain, as explained at
-* http://creativecommons.org/licenses/publicdomain
+* https://creativecommons.org/licenses/publicdomain
 */
 /// <summary> Misc utilities in JSR166 performance tests</summary>
 //UPGRADE_TODO: The package 'edu.emory.mathcs.backport.java.util.concurrent' could not be found. If it was not included in the conversion, there may be compiler issues. "ms-help://MS.VSCC.v80/dv_commoner/local/redirect.htm?index='!DefaultContextWindowIndex'&keyword='jlca1262'"
@@ -20,7 +20,7 @@ class LoopHelpers
     // Some mindless computation to do between synchronizations...
 
     /// <summary> generates 32 bit pseudo-random numbers.
-    /// Adapted from http://www.snippets.org
+    /// Adapted from https://www.snippets.org
     /// </summary>
     public static int compute1(int x)
     {

--- a/test/Spring/Spring.Threading.Tests/Threading/Collections/Generic/PriorityBlockingQueueTest.cs
+++ b/test/Spring/Spring.Threading.Tests/Threading/Collections/Generic/PriorityBlockingQueueTest.cs
@@ -1,7 +1,7 @@
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */
@@ -25,7 +25,7 @@ namespace Spring.Threading.Collections.Generic
     /// Test cases for <see cref="PriorityBlockingQueue{T}"/>.
     /// </summary>
     /// <author>Doug Lea>author>
-    /// <author>Andreas Döhring (.NET)</author>
+    /// <author>Andreas Dï¿½hring (.NET)</author>
     /// <author>Kenneth Xu</author>
     public class PriorityBlockingQueueTest {
 

--- a/test/Spring/Spring.Threading.Tests/Threading/ThreadInterruptionTest.cs
+++ b/test/Spring/Spring.Threading.Tests/Threading/ThreadInterruptionTest.cs
@@ -30,7 +30,7 @@ namespace Spring.Threading
         /// <summary>
         /// Needed to test .Net Thread behaviour when interruped
         /// </summary>
-        /// <seealso>http://opensource.atlassian.com/projects/spring/browse/SPRNET-9</seealso>
+        /// <seealso>https://opensource.atlassian.com/projects/spring/browse/SPRNET-9</seealso>
         private interface IAfterInterruptionStrategy
         {
             void AfterInterruption ();


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://altair.cs.oswego.edu/mailman/listinfo/concurrency-interest (200) with 3 occurrences could not be migrated:  
   ([https](https://altair.cs.oswego.edu/mailman/listinfo/concurrency-interest) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/bibliography/bibliography.xml (200) with 2 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/bibliography/bibliography.xml) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/images/annot-close.png (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/images/annot-close.png) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/images/annot-open.png (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/images/annot-open.png) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/images/draft.png (200) with 2 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/images/draft.png) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/script/AnchorPosition.js (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/script/AnchorPosition.js) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/script/PopupWindow.js (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/script/PopupWindow.js) result AnnotatedConnectException).
* [ ] http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/src/main/java/ (200) with 3 occurrences could not be migrated:  
   ([https](https://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/src/main/java/) result AnnotatedConnectException).
* [ ] http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/src/test/tck/ (200) with 3 occurrences could not be migrated:  
   ([https](https://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/src/test/tck/) result AnnotatedConnectException).
* [ ] http://gee.cs.oswego.edu/dl/classes/EDU/oswego/cs/dl/util/concurrent/intro.html (200) with 4 occurrences could not be migrated:  
   ([https](https://gee.cs.oswego.edu/dl/classes/EDU/oswego/cs/dl/util/concurrent/intro.html) result AnnotatedConnectException).
* [ ] http://gee.cs.oswego.edu/dl/concurrency-interest/ (200) with 6 occurrences could not be migrated:  
   ([https](https://gee.cs.oswego.edu/dl/concurrency-interest/) result AnnotatedConnectException).
* [ ] http://gee.oswego.edu/dl/classes/collections/ (200) with 3 occurrences could not be migrated:  
   ([https](https://gee.oswego.edu/dl/classes/collections/) result AnnotatedConnectException).
* [ ] http://jeuclid.sourceforge.net/ (200) with 1 occurrences could not be migrated:  
   ([https](https://jeuclid.sourceforge.net/) result AnnotatedConnectException).
* [ ] http://retrotranslator.sourceforge.net/ (200) with 1 occurrences could not be migrated:  
   ([https](https://retrotranslator.sourceforge.net/) result AnnotatedConnectException).
* [ ] http://supertech.lcs.mit.edu/cilk/ (200) with 1 occurrences could not be migrated:  
   ([https](https://supertech.lcs.mit.edu/cilk/) result SSLProtocolException).
* [ ] http://www.isogen.com/functions/com.isogen.saxoni18n.Saxoni18nService (200) with 2 occurrences could not be migrated:  
   ([https](https://www.isogen.com/functions/com.isogen.saxoni18n.Saxoni18nService) result SSLHandshakeException).
* [ ] http://www.saxproject.org (200) with 2 occurrences could not be migrated:  
   ([https](https://www.saxproject.org) result AnnotatedConnectException).
* [ ] http://www.saxproject.org/copying.html (200) with 1 occurrences could not be migrated:  
   ([https](https://www.saxproject.org/copying.html) result AnnotatedConnectException).
* [ ] http://xmlunit.sourceforge.net/ (200) with 1 occurrences could not be migrated:  
   ([https](https://xmlunit.sourceforge.net/) result AnnotatedConnectException).
* [ ] http://www.cs.uga.edu/~dkl/filaments/dist.html (301) with 1 occurrences could not be migrated:  
   ([https](https://www.cs.uga.edu/~dkl/filaments/dist.html) result ConnectTimeoutException).
* [ ] http://docbook.sf.net/ (301) with 9 occurrences could not be migrated:  
   ([https](https://docbook.sf.net/) result AnnotatedConnectException).
* [ ] http://docbook.sf.net/release/xsl/current/ (301) with 108 occurrences could not be migrated:  
   ([https](https://docbook.sf.net/release/xsl/current/) result AnnotatedConnectException).
* [ ] http://nant.sf.net/release/0.85/nant.xsd (301) with 1 occurrences could not be migrated:  
   ([https](https://nant.sf.net/release/0.85/nant.xsd) result AnnotatedConnectException).
* [ ] http://saxon.sf.net/ (301) with 1 occurrences could not be migrated:  
   ([https](https://saxon.sf.net/) result AnnotatedConnectException).
* [ ] http://xslthl.sf.net (301) with 3 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).
* [ ] http://freshmeat.net/projects/freshmeat-submit/ (302) with 1 occurrences could not be migrated:  
   ([https](https://freshmeat.net/projects/freshmeat-submit/) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/xmlns/chunkfast/1.0 (404) with 4 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/xmlns/chunkfast/1.0) result AnnotatedConnectException).
* [ ] http://exslt.org/common (404) with 39 occurrences could not be migrated:  
   ([https](https://exslt.org/common) result SSLHandshakeException).
* [ ] http://exslt.org/dates-and-times (404) with 2 occurrences could not be migrated:  
   ([https](https://exslt.org/dates-and-times) result SSLHandshakeException).
* [ ] http://exslt.org/dynamic (404) with 4 occurrences could not be migrated:  
   ([https](https://exslt.org/dynamic) result SSLHandshakeException).
* [ ] http://exslt.org/functions (404) with 3 occurrences could not be migrated:  
   ([https](https://exslt.org/functions) result SSLHandshakeException).
* [ ] http://exslt.org/sets (404) with 7 occurrences could not be migrated:  
   ([https](https://exslt.org/sets) result SSLHandshakeException).
* [ ] http://schemas.microsoft.com/developer/msbuild/2003 (404) with 13 occurrences could not be migrated:  
   ([https](https://schemas.microsoft.com/developer/msbuild/2003) result AnnotatedConnectException).
* [ ] http://www.cs.yorku.ca/~mikhail/ (404) with 3 occurrences could not be migrated:  
   ([https](https://www.cs.yorku.ca/~mikhail/) result SSLHandshakeException).
* [ ] http://www.densis.fee.unicamp.br/~moscato/TSPBIB_home.html (404) with 5 occurrences could not be migrated:  
   ([https](https://www.densis.fee.unicamp.br/~moscato/TSPBIB_home.html) result SSLHandshakeException).
* [ ] http://www.innodata-isogen.com/knowledge_center/tools_downloads/i18nsupport (404) with 2 occurrences could not be migrated:  
   ([https](https://www.innodata-isogen.com/knowledge_center/tools_downloads/i18nsupport) result SSLHandshakeException).
* [ ] http://www.renderx.com/XSL/Extensions (404) with 7 occurrences could not be migrated:  
   ([https](https://www.renderx.com/XSL/Extensions) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-1.0_01/backport-util-concurrent-1.0_01-changelog.html (302) with 3 occurrences migrated to:  
  https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-1.0_01/backport-util-concurrent-1.0_01-changelog.html ([https](https://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-1.0_01/backport-util-concurrent-1.0_01-changelog.html) result ConnectTimeoutException).
* [ ] http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-1.1/backport-util-concurrent-1.1-changelog.html (302) with 3 occurrences migrated to:  
  https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-1.1/backport-util-concurrent-1.1-changelog.html ([https](https://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-1.1/backport-util-concurrent-1.1-changelog.html) result ConnectTimeoutException).
* [ ] http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-1.1_01/backport-util-concurrent-1.1_01-changelog.html (302) with 3 occurrences migrated to:  
  https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-1.1_01/backport-util-concurrent-1.1_01-changelog.html ([https](https://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-1.1_01/backport-util-concurrent-1.1_01-changelog.html) result ConnectTimeoutException).
* [ ] http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-2.0/backport-util-concurrent-2.0-changelog.html (302) with 3 occurrences migrated to:  
  https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-2.0/backport-util-concurrent-2.0-changelog.html ([https](https://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-2.0/backport-util-concurrent-2.0-changelog.html) result ConnectTimeoutException).
* [ ] http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-2.0_01/backport-util-concurrent-2.0_01-changelog.html (302) with 3 occurrences migrated to:  
  https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-2.0_01/backport-util-concurrent-2.0_01-changelog.html ([https](https://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-2.0_01/backport-util-concurrent-2.0_01-changelog.html) result ConnectTimeoutException).
* [ ] http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-2.1/backport-util-concurrent-2.1-changelog.html (302) with 3 occurrences migrated to:  
  https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-2.1/backport-util-concurrent-2.1-changelog.html ([https](https://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-2.1/backport-util-concurrent-2.1-changelog.html) result ConnectTimeoutException).
* [ ] http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-2.2/backport-util-concurrent-2.2-changelog.html (302) with 2 occurrences migrated to:  
  https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-2.2/backport-util-concurrent-2.2-changelog.html ([https](https://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-2.2/backport-util-concurrent-2.2-changelog.html) result ConnectTimeoutException).
* [ ] http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-3.0/backport-util-concurrent-3.0-changelog.html (302) with 1 occurrences migrated to:  
  https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-3.0/backport-util-concurrent-3.0-changelog.html ([https](https://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-3.0/backport-util-concurrent-3.0-changelog.html) result ConnectTimeoutException).
* [ ] http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-3.0/backport-util-concurrent-Java12-3.0-changelog.html (302) with 1 occurrences migrated to:  
  https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-3.0/backport-util-concurrent-Java12-3.0-changelog.html ([https](https://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-3.0/backport-util-concurrent-Java12-3.0-changelog.html) result ConnectTimeoutException).
* [ ] http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-3.0/backport-util-concurrent-Java50-3.0-changelog.html (302) with 1 occurrences migrated to:  
  https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-3.0/backport-util-concurrent-Java50-3.0-changelog.html ([https](https://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-3.0/backport-util-concurrent-Java50-3.0-changelog.html) result ConnectTimeoutException).
* [ ] http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-3.1/backport-util-concurrent-3.1-changelog.html (302) with 1 occurrences migrated to:  
  https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-3.1/backport-util-concurrent-3.1-changelog.html ([https](https://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-3.1/backport-util-concurrent-3.1-changelog.html) result ConnectTimeoutException).
* [ ] http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-3.1/backport-util-concurrent-Java12-3.1-changelog.html (302) with 1 occurrences migrated to:  
  https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-3.1/backport-util-concurrent-Java12-3.1-changelog.html ([https](https://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-3.1/backport-util-concurrent-Java12-3.1-changelog.html) result ConnectTimeoutException).
* [ ] http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-3.1/backport-util-concurrent-Java50-3.1-changelog.html (302) with 1 occurrences migrated to:  
  https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-3.1/backport-util-concurrent-Java50-3.1-changelog.html ([https](https://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-3.1/backport-util-concurrent-Java50-3.1-changelog.html) result ConnectTimeoutException).
* [ ] http://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-3.1/backport-util-concurrent-Java60-3.1-changelog.html (302) with 1 occurrences migrated to:  
  https://dcl.mathcs.emory.edu//util/backport-util-concurrent/dist/backport-util-concurrent-3.1/backport-util-concurrent-Java60-3.1-changelog.html ([https](https://www.mathcs.emory.edu/dcl/util/backport-util-concurrent/dist/backport-util-concurrent-3.1/backport-util-concurrent-Java60-3.1-changelog.html) result ConnectTimeoutException).
* [ ] http://www.antennahouse.com/names/XSL/Extensions (301) with 8 occurrences migrated to:  
  https://www.antennahouse.com/names/XSL/Extensions ([https](https://www.antennahouse.com/names/XSL/Extensions) result ReadTimeoutException).
* [ ] http://www.ercim.org/ (301) with 1 occurrences migrated to:  
  https://www.ercim.eu/ ([https](https://www.ercim.org/) result SSLHandshakeException).
* [ ] http://www.lotus.com (301) with 2 occurrences migrated to:  
  https://www.lotus.com/ ([https](https://www.lotus.com) result SSLHandshakeException).
* [ ] http://tango.freedesktop.org/ (AnnotatedConnectException) with 1 occurrences migrated to:  
  https://tango.freedesktop.org/ ([https](https://tango.freedesktop.org/) result AnnotatedConnectException).
* [ ] http://dcl.mathcs.emory.edu/ (ConnectTimeoutException) with 3 occurrences migrated to:  
  https://dcl.mathcs.emory.edu/ ([https](https://dcl.mathcs.emory.edu/) result ConnectTimeoutException).
* [ ] http://dcl.mathcs.emory.edu/util/backport-util-concurrent/ (ConnectTimeoutException) with 9 occurrences migrated to:  
  https://dcl.mathcs.emory.edu/util/backport-util-concurrent/ ([https](https://dcl.mathcs.emory.edu/util/backport-util-concurrent/) result ConnectTimeoutException).
* [ ] http://kohari.org/2009/03/06/fast-late-bound-invocation-with-expression-trees/ (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://kohari.org/2009/03/06/fast-late-bound-invocation-with-expression-trees/ ([https](https://kohari.org/2009/03/06/fast-late-bound-invocation-with-expression-trees/) result ConnectTimeoutException).
* [ ] http://www.dpawson.co.uk/xsl/index.html (ConnectTimeoutException) with 2 occurrences migrated to:  
  https://www.dpawson.co.uk/xsl/index.html ([https](https://www.dpawson.co.uk/xsl/index.html) result ConnectTimeoutException).
* [ ] http://www.dpawson.co.uk/xsl/sect2/StringReplace.html (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://www.dpawson.co.uk/xsl/sect2/StringReplace.html ([https](https://www.dpawson.co.uk/xsl/sect2/StringReplace.html) result ConnectTimeoutException).
* [ ] http://www.dpawson.co.uk/xsl/sect2/padding.html (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://www.dpawson.co.uk/xsl/sect2/padding.html ([https](https://www.dpawson.co.uk/xsl/sect2/padding.html) result ConnectTimeoutException).
* [ ] http://www.vogella.de/articles/JavaConcurrency/article.html (ConnectTimeoutException) with 2 occurrences migrated to:  
  https://www.vogella.de/articles/JavaConcurrency/article.html ([https](https://www.vogella.de/articles/JavaConcurrency/article.html) result ConnectTimeoutException).
* [ ] http://www.w3.org (ReadTimeoutException) with 2 occurrences migrated to:  
  https://www.w3.org ([https](https://www.w3.org) result ReadTimeoutException).
* [ ] http://www.w3.org/TR/html4/loose.dtd (ReadTimeoutException) with 2 occurrences migrated to:  
  https://www.w3.org/TR/html4/loose.dtd ([https](https://www.w3.org/TR/html4/loose.dtd) result ReadTimeoutException).
* [ ] http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd (ReadTimeoutException) with 1 occurrences migrated to:  
  https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd ([https](https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd) result ReadTimeoutException).
* [ ] http://icl.com/saxon (UnknownHostException) with 8 occurrences migrated to:  
  https://icl.com/saxon ([https](https://icl.com/saxon) result UnknownHostException).
* [ ] http://nagoya.apache.org/bugzilla/show_bug.cgi?id=6063 (UnknownHostException) with 1 occurrences migrated to:  
  https://nagoya.apache.org/bugzilla/show_bug.cgi?id=6063 ([https](https://nagoya.apache.org/bugzilla/show_bug.cgi?id=6063) result UnknownHostException).
* [ ] http://net.sf.xslthl/ConnectorSaxon6 (UnknownHostException) with 1 occurrences migrated to:  
  https://net.sf.xslthl/ConnectorSaxon6 ([https](https://net.sf.xslthl/ConnectorSaxon6) result UnknownHostException).
* [ ] http://net.sf.xslthl/ConnectorSaxonB (UnknownHostException) with 1 occurrences migrated to:  
  https://net.sf.xslthl/ConnectorSaxonB ([https](https://net.sf.xslthl/ConnectorSaxonB) result UnknownHostException).
* [ ] http://net.sf.xslthl/ConnectorXalan (UnknownHostException) with 1 occurrences migrated to:  
  https://net.sf.xslthl/ConnectorXalan ([https](https://net.sf.xslthl/ConnectorXalan) result UnknownHostException).
* [ ] http://org.apache.xalan.lib.NodeInfo (UnknownHostException) with 1 occurrences migrated to:  
  https://org.apache.xalan.lib.NodeInfo ([https](https://org.apache.xalan.lib.NodeInfo) result UnknownHostException).
* [ ] http://www.research.ibm.com/people/m/michael/pubs.htm (403) with 3 occurrences migrated to:  
  https://www.research.ibm.com/people/m/michael/pubs.htm ([https](https://www.research.ibm.com/people/m/michael/pubs.htm) result 403).
* [ ] http://docbook.org/xlink/role/olink (301) with 4 occurrences migrated to:  
  https://docbook.org/xlink/role/olink ([https](https://docbook.org/xlink/role/olink) result 404).
* [ ] http://docbook.svn.sourceforge.net/viewvc/docbook/ (404) with 1 occurrences migrated to:  
  https://docbook.svn.sourceforge.net/viewvc/docbook/ ([https](https://docbook.svn.sourceforge.net/viewvc/docbook/) result 404).
* [ ] http://example.com/cgi-bin/man.cgi (404) with 1 occurrences migrated to:  
  https://example.com/cgi-bin/man.cgi ([https](https://example.com/cgi-bin/man.cgi) result 404).
* [ ] http://nwalsh.com/xsl/documentation/1.0 (302) with 30 occurrences migrated to:  
  https://nwalsh.com/xsl/documentation/1.0 ([https](https://nwalsh.com/xsl/documentation/1.0) result 404).
* [ ] http://nwalsh.com/xslt/ext/com.nwalsh.saxon.ImageIntrinsics (302) with 1 occurrences migrated to:  
  https://nwalsh.com/xslt/ext/com.nwalsh.saxon.ImageIntrinsics ([https](https://nwalsh.com/xslt/ext/com.nwalsh.saxon.ImageIntrinsics) result 404).
* [ ] http://nwalsh.com/xslt/ext/com.nwalsh.saxon.Table (302) with 2 occurrences migrated to:  
  https://nwalsh.com/xslt/ext/com.nwalsh.saxon.Table ([https](https://nwalsh.com/xslt/ext/com.nwalsh.saxon.Table) result 404).
* [ ] http://nwalsh.com/xslt/ext/com.nwalsh.saxon.TextFactory (302) with 2 occurrences migrated to:  
  https://nwalsh.com/xslt/ext/com.nwalsh.saxon.TextFactory ([https](https://nwalsh.com/xslt/ext/com.nwalsh.saxon.TextFactory) result 404).
* [ ] http://nwalsh.com/xslt/ext/com.nwalsh.saxon.UnwrapLinks (302) with 2 occurrences migrated to:  
  https://nwalsh.com/xslt/ext/com.nwalsh.saxon.UnwrapLinks ([https](https://nwalsh.com/xslt/ext/com.nwalsh.saxon.UnwrapLinks) result 404).
* [ ] http://nwalsh.com/xslt/ext/com.nwalsh.saxon.Verbatim (302) with 4 occurrences migrated to:  
  https://nwalsh.com/xslt/ext/com.nwalsh.saxon.Verbatim ([https](https://nwalsh.com/xslt/ext/com.nwalsh.saxon.Verbatim) result 404).
* [ ] http://nwalsh.com/xslt/ext/xsltproc/python/Table (302) with 2 occurrences migrated to:  
  https://nwalsh.com/xslt/ext/xsltproc/python/Table ([https](https://nwalsh.com/xslt/ext/xsltproc/python/Table) result 404).
* [ ] http://prdownloads.sourceforge.net/docbook/ (404) with 3 occurrences migrated to:  
  https://prdownloads.sourceforge.net/docbook/ ([https](https://prdownloads.sourceforge.net/docbook/) result 404).
* [ ] http://sideshowbarker.net/ns (301) with 2 occurrences migrated to:  
  https://sideshowbarker.net/ns ([https](https://sideshowbarker.net/ns) result 404).
* [ ] http://sourceforge.net/project/shownotes.php?release_id= (302) with 1 occurrences migrated to:  
  https://sourceforge.net/p/legacy_/project/shownotes.php?release_id= ([https](https://sourceforge.net/project/shownotes.php?release_id=) result 404).
* [ ] http://www.cl.cam.ac.uk/~tlh20/publications.html (302) with 3 occurrences migrated to:  
  https://www.cl.cam.ac.uk/~tlh20/publications.html ([https](https://www.cl.cam.ac.uk/~tlh20/publications.html) result 404).
* [ ] http://www.cs.rochester.edu/u/michael/PODC96.html (404) with 4 occurrences migrated to:  
  https://www.cs.rochester.edu/u/michael/PODC96.html ([https](https://www.cs.rochester.edu/u/michael/PODC96.html) result 404).
* [ ] http://www.cs.utexas.edu/users/hood/ (404) with 1 occurrences migrated to:  
  https://www.cs.utexas.edu/users/hood/ ([https](https://www.cs.utexas.edu/users/hood/) result 404).
* [ ] http://www.tug.org/fotex (404) with 8 occurrences migrated to:  
  https://www.tug.org/fotex ([https](https://www.tug.org/fotex) result 404).
* [ ] http://www.w3.org/Consortium/Legal/copyright-documents-20021231 (404) with 1 occurrences migrated to:  
  https://www.w3.org/Consortium/Legal/copyright-documents-20021231 ([https](https://www.w3.org/Consortium/Legal/copyright-documents-20021231) result 404).
* [ ] http://www.w3.org/Consortium/Legal/copyright-software-20021231 (404) with 1 occurrences migrated to:  
  https://www.w3.org/Consortium/Legal/copyright-software-20021231 ([https](https://www.w3.org/Consortium/Legal/copyright-software-20021231) result 404).
* [ ] http://xml.apache.org/xalan/redirect (404) with 2 occurrences migrated to:  
  https://xml.apache.org/xalan/redirect ([https](https://xml.apache.org/xalan/redirect) result 404).
* [ ] http://xml.apache.org/xslt (404) with 10 occurrences migrated to:  
  https://xml.apache.org/xslt ([https](https://xml.apache.org/xslt) result 404).
* [ ] http://xmlgraphics.apache.org/fop/extensions (301) with 1 occurrences migrated to:  
  https://xmlgraphics.apache.org/fop/extensions ([https](https://xmlgraphics.apache.org/fop/extensions) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://ant.apache.org with 1 occurrences migrated to:  
  https://ant.apache.org ([https](https://ant.apache.org) result 200).
* [ ] http://dev.w3.org/cvsweb/java/classes/org/w3c/dom/smil/ with 1 occurrences migrated to:  
  https://dev.w3.org/cvsweb/java/classes/org/w3c/dom/smil/ ([https](https://dev.w3.org/cvsweb/java/classes/org/w3c/dom/smil/) result 200).
* [ ] http://dx.doi.org/ with 2 occurrences migrated to:  
  https://dx.doi.org/ ([https](https://dx.doi.org/) result 200).
* [ ] http://excalibur.apache.org/framework/ with 1 occurrences migrated to:  
  https://excalibur.apache.org/framework/ ([https](https://excalibur.apache.org/framework/) result 200).
* [ ] http://lists.oasis-open.org/archives/docbook-apps/ with 1 occurrences migrated to:  
  https://lists.oasis-open.org/archives/docbook-apps/ ([https](https://lists.oasis-open.org/archives/docbook-apps/) result 200).
* [ ] http://sourceforge.net/ with 1 occurrences migrated to:  
  https://sourceforge.net/ ([https](https://sourceforge.net/) result 200).
* [ ] http://sourceforge.net/projects/docbook/ with 1 occurrences migrated to:  
  https://sourceforge.net/projects/docbook/ ([https](https://sourceforge.net/projects/docbook/) result 200).
* [ ] http://www.apache.org/ with 15 occurrences migrated to:  
  https://www.apache.org/ ([https](https://www.apache.org/) result 200).
* [ ] http://www.cs.umd.edu/~pugh/ with 3 occurrences migrated to:  
  https://www.cs.umd.edu/~pugh/ ([https](https://www.cs.umd.edu/~pugh/) result 200).
* [ ] http://www.lcs.mit.edu/ (301) with 3 occurrences migrated to:  
  https://www.csail.mit.edu/ ([https](https://www.lcs.mit.edu/) result 200).
* [ ] http://www.dotnetcurry.com/ShowArticle.aspx?ID=489 with 1 occurrences migrated to:  
  https://www.dotnetcurry.com/ShowArticle.aspx?ID=489 ([https](https://www.dotnetcurry.com/ShowArticle.aspx?ID=489) result 200).
* [ ] http://www.dotnetcurry.com/ShowArticle.aspx?ID=489&AspxAutoDetectCookieSupport=1 with 1 occurrences migrated to:  
  https://www.dotnetcurry.com/ShowArticle.aspx?ID=489&AspxAutoDetectCookieSupport=1 ([https](https://www.dotnetcurry.com/ShowArticle.aspx?ID=489&AspxAutoDetectCookieSupport=1) result 200).
* [ ] http://www.gnu.org/philosophy/license-list.html with 1 occurrences migrated to:  
  https://www.gnu.org/philosophy/license-list.html ([https](https://www.gnu.org/philosophy/license-list.html) result 200).
* [ ] http://www.inria.fr/ with 2 occurrences migrated to:  
  https://www.inria.fr/ ([https](https://www.inria.fr/) result 200).
* [ ] http://www.snippets.org with 4 occurrences migrated to:  
  https://www.snippets.org ([https](https://www.snippets.org) result 200).
* [ ] http://www.w3.org/ with 3 occurrences migrated to:  
  https://www.w3.org/ ([https](https://www.w3.org/) result 200).
* [ ] http://www.w3.org/2002/06/sacjava-1.3.zip with 1 occurrences migrated to:  
  https://www.w3.org/2002/06/sacjava-1.3.zip ([https](https://www.w3.org/2002/06/sacjava-1.3.zip) result 200).
* [ ] http://www.w3.org/Consortium/Legal/2002/copyright-documents-20021231 with 6 occurrences migrated to:  
  https://www.w3.org/Consortium/Legal/2002/copyright-documents-20021231 ([https](https://www.w3.org/Consortium/Legal/2002/copyright-documents-20021231) result 200).
* [ ] http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231 with 3 occurrences migrated to:  
  https://www.w3.org/Consortium/Legal/2002/copyright-software-20021231 ([https](https://www.w3.org/Consortium/Legal/2002/copyright-software-20021231) result 200).
* [ ] http://www.w3.org/Consortium/Legal/2002/copyright-software-short-notice-20021231.html with 1 occurrences migrated to:  
  https://www.w3.org/Consortium/Legal/2002/copyright-software-short-notice-20021231.html ([https](https://www.w3.org/Consortium/Legal/2002/copyright-software-short-notice-20021231.html) result 200).
* [ ] http://www.w3.org/Consortium/Legal/copyright-documents-19990405 with 1 occurrences migrated to:  
  https://www.w3.org/Consortium/Legal/copyright-documents-19990405 ([https](https://www.w3.org/Consortium/Legal/copyright-documents-19990405) result 200).
* [ ] http://www.w3.org/Consortium/Legal/copyright-software-19980720 with 3 occurrences migrated to:  
  https://www.w3.org/Consortium/Legal/copyright-software-19980720 ([https](https://www.w3.org/Consortium/Legal/copyright-software-19980720) result 200).
* [ ] http://www.w3.org/DOM/DOMTR with 1 occurrences migrated to:  
  https://www.w3.org/DOM/DOMTR ([https](https://www.w3.org/DOM/DOMTR) result 200).
* [ ] http://www.w3.org/Style/CSS/SAC/ with 1 occurrences migrated to:  
  https://www.w3.org/Style/CSS/SAC/ ([https](https://www.w3.org/Style/CSS/SAC/) result 200).
* [ ] http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-html.html with 1 occurrences migrated to:  
  https://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-html.html ([https](https://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-html.html) result 200).
* [ ] http://www.w3.org/TR/2000/REC-DOM-Level-2-Events-20001113/ with 1 occurrences migrated to:  
  https://www.w3.org/TR/2000/REC-DOM-Level-2-Events-20001113/ ([https](https://www.w3.org/TR/2000/REC-DOM-Level-2-Events-20001113/) result 200).
* [ ] http://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/ with 1 occurrences migrated to:  
  https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/ ([https](https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/) result 200).
* [ ] http://www.w3.org/TR/2000/REC-DOM-Level-2-Traversal-Range-20001113/ with 1 occurrences migrated to:  
  https://www.w3.org/TR/2000/REC-DOM-Level-2-Traversal-Range-20001113/ ([https](https://www.w3.org/TR/2000/REC-DOM-Level-2-Traversal-Range-20001113/) result 200).
* [ ] http://www.w3.org/TR/2000/REC-DOM-Level-2-Views-20001113/ with 1 occurrences migrated to:  
  https://www.w3.org/TR/2000/REC-DOM-Level-2-Views-20001113/ ([https](https://www.w3.org/TR/2000/REC-DOM-Level-2-Views-20001113/) result 200).
* [ ] http://www.w3.org/TR/2004/NOTE-DOM-Level-3-XPath-20040226/ with 1 occurrences migrated to:  
  https://www.w3.org/TR/2004/NOTE-DOM-Level-3-XPath-20040226/ ([https](https://www.w3.org/TR/2004/NOTE-DOM-Level-3-XPath-20040226/) result 200).
* [ ] http://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/ with 1 occurrences migrated to:  
  https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/ ([https](https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/) result 200).
* [ ] http://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/java-binding.html with 1 occurrences migrated to:  
  https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/java-binding.html ([https](https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/java-binding.html) result 200).
* [ ] http://www.w3.org/TR/2004/REC-DOM-Level-3-LS-20040407/ with 1 occurrences migrated to:  
  https://www.w3.org/TR/2004/REC-DOM-Level-3-LS-20040407/ ([https](https://www.w3.org/TR/2004/REC-DOM-Level-3-LS-20040407/) result 200).
* [ ] http://www.w3.org/TR/SVG11/java.html with 1 occurrences migrated to:  
  https://www.w3.org/TR/SVG11/java.html ([https](https://www.w3.org/TR/SVG11/java.html) result 200).
* [ ] http://www.w3.org/TR/xslt20/ with 2 occurrences migrated to:  
  https://www.w3.org/TR/xslt20/ ([https](https://www.w3.org/TR/xslt20/) result 200).
* [ ] http://xalan.apache.org with 1 occurrences migrated to:  
  https://xalan.apache.org ([https](https://xalan.apache.org) result 200).
* [ ] http://xerces.apache.org with 1 occurrences migrated to:  
  https://xerces.apache.org ([https](https://xerces.apache.org) result 200).
* [ ] http://xml.apache.org/xalan-j/faq.html with 1 occurrences migrated to:  
  https://xml.apache.org/xalan-j/faq.html ([https](https://xml.apache.org/xalan-j/faq.html) result 200).
* [ ] http://xmlgraphics.apache.org/ with 1 occurrences migrated to:  
  https://xmlgraphics.apache.org/ ([https](https://xmlgraphics.apache.org/) result 200).
* [ ] http://xmlgraphics.apache.org/batik/ with 1 occurrences migrated to:  
  https://xmlgraphics.apache.org/batik/ ([https](https://xmlgraphics.apache.org/batik/) result 200).
* [ ] http://docbook.org/docbook-ng with 10 occurrences migrated to:  
  https://docbook.org/docbook-ng ([https](https://docbook.org/docbook-ng) result 301).
* [ ] http://doi.org with 2 occurrences migrated to:  
  https://doi.org ([https](https://doi.org) result 301).
* [ ] http://google.com/ with 1 occurrences migrated to:  
  https://google.com/ ([https](https://google.com/) result 301).
* [ ] http://jakarta.apache.org/commons/io/ with 1 occurrences migrated to:  
  https://jakarta.apache.org/commons/io/ ([https](https://jakarta.apache.org/commons/io/) result 301).
* [ ] http://jakarta.apache.org/commons/logging/ with 1 occurrences migrated to:  
  https://jakarta.apache.org/commons/logging/ ([https](https://jakarta.apache.org/commons/logging/) result 301).
* [ ] http://jakarta.apache.org/tomcat/ with 1 occurrences migrated to:  
  https://jakarta.apache.org/tomcat/ ([https](https://jakarta.apache.org/tomcat/) result 301).
* [ ] http://opensource.atlassian.com/projects/spring/browse/SPRNET-9 with 1 occurrences migrated to:  
  https://opensource.atlassian.com/projects/spring/browse/SPRNET-9 ([https](https://opensource.atlassian.com/projects/spring/browse/SPRNET-9) result 301).
* [ ] http://sourceforge.net/projects/jeuclid with 1 occurrences migrated to:  
  https://sourceforge.net/projects/jeuclid ([https](https://sourceforge.net/projects/jeuclid) result 301).
* [ ] http://www.cs.chalmers.se/~phs/ (301) with 3 occurrences migrated to:  
  https://www.chalmers.se/cse ([https](https://www.cs.chalmers.se/~phs/) result 301).
* [ ] http://www.cl.cam.ac.uk/users/kaf24/ with 3 occurrences migrated to:  
  https://www.cl.cam.ac.uk/users/kaf24/ ([https](https://www.cl.cam.ac.uk/users/kaf24/) result 301).
* [ ] http://docbook.sf.net/el/date (301) with 1 occurrences migrated to:  
  https://www.docbook.org/tdg5/en/html/date.html ([https](https://docbook.sf.net/el/date) result 301).
* [ ] http://docbook.sf.net/el/manvolnum (301) with 1 occurrences migrated to:  
  https://www.docbook.org/tdg5/en/html/manvolnum.html ([https](https://docbook.sf.net/el/manvolnum) result 301).
* [ ] http://docbook.sf.net/el/productname (301) with 1 occurrences migrated to:  
  https://www.docbook.org/tdg5/en/html/productname.html ([https](https://docbook.sf.net/el/productname) result 301).
* [ ] http://docbook.sf.net/el/productnumber (301) with 1 occurrences migrated to:  
  https://www.docbook.org/tdg5/en/html/productnumber.html ([https](https://docbook.sf.net/el/productnumber) result 301).
* [ ] http://docbook.sf.net/el/refmiscinfo (301) with 3 occurrences migrated to:  
  https://www.docbook.org/tdg5/en/html/refmiscinfo.html ([https](https://docbook.sf.net/el/refmiscinfo) result 301).
* [ ] http://www.jesusda.com/projects/pasodoble with 1 occurrences migrated to:  
  https://www.jesusda.com/projects/pasodoble ([https](https://www.jesusda.com/projects/pasodoble) result 301).
* [ ] http://www.junit.org with 1 occurrences migrated to:  
  https://www.junit.org ([https](https://www.junit.org) result 301).
* [ ] http://www.opensource.org/docs/definition.php with 1 occurrences migrated to:  
  https://www.opensource.org/docs/definition.php ([https](https://www.opensource.org/docs/definition.php) result 301).
* [ ] http://www.opensource.org/licenses/W3C.php with 1 occurrences migrated to:  
  https://www.opensource.org/licenses/W3C.php ([https](https://www.opensource.org/licenses/W3C.php) result 301).
* [ ] http://www.opensource.org/licenses/historical.php with 1 occurrences migrated to:  
  https://www.opensource.org/licenses/historical.php ([https](https://www.opensource.org/licenses/historical.php) result 301).
* [ ] http://www.springsource.com/ with 2 occurrences migrated to:  
  https://www.springsource.com/ ([https](https://www.springsource.com/) result 301).
* [ ] http://www.sun.com with 5 occurrences migrated to:  
  https://www.sun.com ([https](https://www.sun.com) result 301).
* [ ] http://xml.apache.org/commons/components/external/ with 2 occurrences migrated to:  
  https://xml.apache.org/commons/components/external/ ([https](https://xml.apache.org/commons/components/external/) result 301).
* [ ] http://xml.apache.org/xalan with 1 occurrences migrated to:  
  https://xml.apache.org/xalan ([https](https://xml.apache.org/xalan) result 301).
* [ ] http://avalon.apache.org with 1 occurrences migrated to:  
  https://avalon.apache.org ([https](https://avalon.apache.org) result 302).
* [ ] http://creativecommons.org/licenses/publicdomain with 507 occurrences migrated to:  
  https://creativecommons.org/licenses/publicdomain ([https](https://creativecommons.org/licenses/publicdomain) result 302).
* [ ] http://java.sun.com/docs/books/jls/ with 6 occurrences migrated to:  
  https://java.sun.com/docs/books/jls/ ([https](https://java.sun.com/docs/books/jls/) result 302).
* [ ] http://java.sun.com/docs/books/jls/third_edition/html/memory.html with 3 occurrences migrated to:  
  https://java.sun.com/docs/books/jls/third_edition/html/memory.html ([https](https://java.sun.com/docs/books/jls/third_edition/html/memory.html) result 302).
* [ ] http://java.sun.com/j2se/1.4.2/docs/guide/standards/index.html with 1 occurrences migrated to:  
  https://java.sun.com/j2se/1.4.2/docs/guide/standards/index.html ([https](https://java.sun.com/j2se/1.4.2/docs/guide/standards/index.html) result 302).
* [ ] http://java.sun.com/j2se/1.5.0/docs/guide/concurrency/overview.html with 6 occurrences migrated to:  
  https://java.sun.com/j2se/1.5.0/docs/guide/concurrency/overview.html ([https](https://java.sun.com/j2se/1.5.0/docs/guide/concurrency/overview.html) result 302).
* [ ] http://java.sun.com/j2se/1.5.0/docs/guide/language/generics.html with 3 occurrences migrated to:  
  https://java.sun.com/j2se/1.5.0/docs/guide/language/generics.html ([https](https://java.sun.com/j2se/1.5.0/docs/guide/language/generics.html) result 302).
* [ ] http://java.sun.com/products/java-media/jai with 1 occurrences migrated to:  
  https://java.sun.com/products/java-media/jai ([https](https://java.sun.com/products/java-media/jai) result 302).
* [ ] http://www.keio.ac.jp/ with 3 occurrences migrated to:  
  https://www.keio.ac.jp/ ([https](https://www.keio.ac.jp/) result 302).
* [ ] http://www.w3.org/Consortium/Legal/ with 4 occurrences migrated to:  
  https://www.w3.org/Consortium/Legal/ ([https](https://www.w3.org/Consortium/Legal/) result 302).
* [ ] http://www.w3.org/Consortium/Legal/IPR-FAQ with 4 occurrences migrated to:  
  https://www.w3.org/Consortium/Legal/IPR-FAQ ([https](https://www.w3.org/Consortium/Legal/IPR-FAQ) result 302).
* [ ] http://www.w3.org/Consortium/Legal/copyright-documents with 2 occurrences migrated to:  
  https://www.w3.org/Consortium/Legal/copyright-documents ([https](https://www.w3.org/Consortium/Legal/copyright-documents) result 302).
* [ ] http://www.w3.org/Consortium/Legal/copyright-software with 2 occurrences migrated to:  
  https://www.w3.org/Consortium/Legal/copyright-software ([https](https://www.w3.org/Consortium/Legal/copyright-software) result 302).
* [ ] http://www.ibm.com with 7 occurrences migrated to:  
  https://www.ibm.com ([https](https://www.ibm.com) result 303).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 11 occurrences
* http://docbook.sourceforge.net/xmlns/l10n/1.0 with 5 occurrences
* http://www.springframework.net with 1 occurrences
* http://www.springframework.net/ with 1 occurrences
* http://www.w3.org/1998/Math/MathML with 7 occurrences
* http://www.w3.org/1999/XSL/Format with 339 occurrences
* http://www.w3.org/1999/XSL/Transform with 151 occurrences
* http://www.w3.org/1999/xhtml with 8 occurrences
* http://www.w3.org/1999/xlink with 12 occurrences
* http://www.w3.org/2000/svg with 3 occurrences
* http://www.w3.org/2001/XInclude with 1 occurrences
* http://www.w3.org/TR/xhtml1/transitional with 2 occurrences