### PR TITLE
URL Cleanup

### DIFF
--- a/doc/reference/lib/fop-0.95/lib/README.txt
+++ b/doc/reference/lib/fop-0.95/lib/README.txt
@@ -5,7 +5,7 @@ Information on Apache FOP dependencies
 $Id$
 
 The Apache Licenses can also be found here:
-http://www.apache.org/licenses/
+https://www.apache.org/licenses/
 
 
 Normal Dependencies

--- a/doc/reference/lib/fop-0.95/lib/avalon-framework.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/avalon-framework.LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 

--- a/doc/reference/lib/fop-0.95/lib/batik.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/batik.LICENSE.txt
@@ -1,6 +1,6 @@
                                   Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/commons-io.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/commons-io.LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/commons-logging.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/commons-logging.LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/serializer.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/serializer.LICENSE.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/xalan.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xalan.LICENSE.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/xercesImpl.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xercesImpl.LICENSE.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/xml-apis-ext.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xml-apis-ext.LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/xml-apis.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xml-apis.LICENSE.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/xmlgraphics-commons.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xmlgraphics-commons.LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Collections/Generic/AbstractCollection.cs
+++ b/src/Spring/Spring.Threading/Collections/Generic/AbstractCollection.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Collections/Generic/AbstractEnumerator.cs
+++ b/src/Spring/Spring.Threading/Collections/Generic/AbstractEnumerator.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Collections/Generic/AbstractList.cs
+++ b/src/Spring/Spring.Threading/Collections/Generic/AbstractList.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Collections/Generic/AbstractQueue.cs
+++ b/src/Spring/Spring.Threading/Collections/Generic/AbstractQueue.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Collections/Generic/AbstractTransformingList.cs
+++ b/src/Spring/Spring.Threading/Collections/Generic/AbstractTransformingList.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Collections/Generic/ArrayQueue.cs
+++ b/src/Spring/Spring.Threading/Collections/Generic/ArrayQueue.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Collections/Generic/DictionarySet.cs
+++ b/src/Spring/Spring.Threading/Collections/Generic/DictionarySet.cs
@@ -1,15 +1,15 @@
-/* Copyright © 2002-2004 by Aidant Systems, Inc., and by Jason Smith. */
+/* Copyright ï¿½ 2002-2004 by Aidant Systems, Inc., and by Jason Smith. */
 
 #region License
 
 /*
- * Copyright © 2002-2005 the original author or authors.
+ * Copyright ï¿½ 2002-2005 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Collections/Generic/DownCastList.cs
+++ b/src/Spring/Spring.Threading/Collections/Generic/DownCastList.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Collections/Generic/HashedSet.cs
+++ b/src/Spring/Spring.Threading/Collections/Generic/HashedSet.cs
@@ -1,15 +1,15 @@
-/* Copyright © 2002-2004 by Aidant Systems, Inc., and by Jason Smith. */
+/* Copyright ï¿½ 2002-2004 by Aidant Systems, Inc., and by Jason Smith. */
 
 #region License
 
 /*
- * Copyright © 2002-2005 the original author or authors.
+ * Copyright ï¿½ 2002-2005 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Collections/Generic/INavigableDictionary.cs
+++ b/src/Spring/Spring.Threading/Collections/Generic/INavigableDictionary.cs
@@ -1,13 +1,13 @@
 #region License
 
 /*
- * Copyright © 2002-2006 the original author or authors.
+ * Copyright ï¿½ 2002-2006 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Collections/Generic/INavigableSet.cs
+++ b/src/Spring/Spring.Threading/Collections/Generic/INavigableSet.cs
@@ -1,13 +1,13 @@
 #region License
 
 /*
- * Copyright © 2002-2005 the original author or authors.
+ * Copyright ï¿½ 2002-2005 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Collections/Generic/IQueue.cs
+++ b/src/Spring/Spring.Threading/Collections/Generic/IQueue.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Collections/Generic/ISet.cs
+++ b/src/Spring/Spring.Threading/Collections/Generic/ISet.cs
@@ -9,7 +9,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Collections/Generic/ISortedDictionary.cs
+++ b/src/Spring/Spring.Threading/Collections/Generic/ISortedDictionary.cs
@@ -1,13 +1,13 @@
 #region License
 
 /*
- * Copyright © 2002-2006 the original author or authors.
+ * Copyright ï¿½ 2002-2006 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Collections/Generic/PriorityQueue.cs
+++ b/src/Spring/Spring.Threading/Collections/Generic/PriorityQueue.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Collections/Generic/Set.cs
+++ b/src/Spring/Spring.Threading/Collections/Generic/Set.cs
@@ -1,15 +1,15 @@
-/* Copyright © 2002-2004 by Aidant Systems, Inc., and by Jason Smith. */
+/* Copyright ï¿½ 2002-2004 by Aidant Systems, Inc., and by Jason Smith. */
 
 #region License
 
 /*
- * Copyright © 2002-2005 the original author or authors.
+ * Copyright ï¿½ 2002-2005 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Collections/Generic/SortedSet.cs
+++ b/src/Spring/Spring.Threading/Collections/Generic/SortedSet.cs
@@ -1,15 +1,15 @@
-/* Copyright © 2002-2004 by Aidant Systems, Inc., and by Jason Smith. */
+/* Copyright ï¿½ 2002-2004 by Aidant Systems, Inc., and by Jason Smith. */
 
 #region License
 
 /*
- * Copyright © 2002-2005 the original author or authors.
+ * Copyright ï¿½ 2002-2005 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Collections/Generic/TransformingEnumerator.cs
+++ b/src/Spring/Spring.Threading/Collections/Generic/TransformingEnumerator.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Collections/Generic/TransformingList.cs
+++ b/src/Spring/Spring.Threading/Collections/Generic/TransformingList.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/System/AggregateException.cs
+++ b/src/Spring/Spring.Threading/System/AggregateException.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/System/Threading/Tasks/OrderProcessor.cs
+++ b/src/Spring/Spring.Threading/System/Threading/Tasks/OrderProcessor.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/System/Threading/Tasks/Parallel.cs
+++ b/src/Spring/Spring.Threading/System/Threading/Tasks/Parallel.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/System/Threading/Tasks/ParallelLoopResult.cs
+++ b/src/Spring/Spring.Threading/System/Threading/Tasks/ParallelLoopResult.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/System/Threading/Tasks/ParallelOptions.cs
+++ b/src/Spring/Spring.Threading/System/Threading/Tasks/ParallelOptions.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/AtomicTypes/AbstractAtomicArray.cs
+++ b/src/Spring/Spring.Threading/Threading/AtomicTypes/AbstractAtomicArray.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/AtomicTypes/Atomic.cs
+++ b/src/Spring/Spring.Threading/Threading/AtomicTypes/Atomic.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/AtomicTypes/AtomicArray.cs
+++ b/src/Spring/Spring.Threading/Threading/AtomicTypes/AtomicArray.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/AtomicTypes/AtomicBoolean.cs
+++ b/src/Spring/Spring.Threading/Threading/AtomicTypes/AtomicBoolean.cs
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/AtomicTypes/AtomicInteger.cs
+++ b/src/Spring/Spring.Threading/Threading/AtomicTypes/AtomicInteger.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/AtomicTypes/AtomicIntegerArray.cs
+++ b/src/Spring/Spring.Threading/Threading/AtomicTypes/AtomicIntegerArray.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/AtomicTypes/AtomicLong.cs
+++ b/src/Spring/Spring.Threading/Threading/AtomicTypes/AtomicLong.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/AtomicTypes/AtomicLongArray.cs
+++ b/src/Spring/Spring.Threading/Threading/AtomicTypes/AtomicLongArray.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/AtomicTypes/AtomicMarkable.cs
+++ b/src/Spring/Spring.Threading/Threading/AtomicTypes/AtomicMarkable.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/AtomicTypes/AtomicMarkableReference.cs
+++ b/src/Spring/Spring.Threading/Threading/AtomicTypes/AtomicMarkableReference.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/AtomicTypes/AtomicReference.cs
+++ b/src/Spring/Spring.Threading/Threading/AtomicTypes/AtomicReference.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/AtomicTypes/AtomicReferenceArray.cs
+++ b/src/Spring/Spring.Threading/Threading/AtomicTypes/AtomicReferenceArray.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/AtomicTypes/AtomicStamped.cs
+++ b/src/Spring/Spring.Threading/Threading/AtomicTypes/AtomicStamped.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/AtomicTypes/AtomicStampedReference.cs
+++ b/src/Spring/Spring.Threading/Threading/AtomicTypes/AtomicStampedReference.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/AtomicTypes/IAtomic.cs
+++ b/src/Spring/Spring.Threading/Threading/AtomicTypes/IAtomic.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/AtomicTypes/IAtomicArray.cs
+++ b/src/Spring/Spring.Threading/Threading/AtomicTypes/IAtomicArray.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/AtomicTypes/ValueHolder.cs
+++ b/src/Spring/Spring.Threading/Threading/AtomicTypes/ValueHolder.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/BoundedBuffer.cs
+++ b/src/Spring/Spring.Threading/Threading/BoundedBuffer.cs
@@ -1,12 +1,12 @@
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/BoundedLinkedQueue.cs
+++ b/src/Spring/Spring.Threading/Threading/BoundedLinkedQueue.cs
@@ -1,12 +1,12 @@
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/BoundedPriorityQueue.cs
+++ b/src/Spring/Spring.Threading/Threading/BoundedPriorityQueue.cs
@@ -2,13 +2,13 @@ using System;
 
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/BrokenBarrierException.cs
+++ b/src/Spring/Spring.Threading/Threading/BrokenBarrierException.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Callable.cs
+++ b/src/Spring/Spring.Threading/Threading/Callable.cs
@@ -7,7 +7,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/ClockDaemon.cs
+++ b/src/Spring/Spring.Threading/Threading/ClockDaemon.cs
@@ -1,12 +1,12 @@
 //#region License
 //*
-//* Copyright © 2002-2005 the original author or authors.
+//* Copyright ï¿½ 2002-2005 the original author or authors.
 //* 
 //* Licensed under the Apache License, Version 2.0 (the "License");
 //* you may not use this file except in compliance with the License.
 //* You may obtain a copy of the License at
 //* 
-//*      http://www.apache.org/licenses/LICENSE-2.0
+//*      https://www.apache.org/licenses/LICENSE-2.0
 //* 
 //* Unless required by applicable law or agreed to in writing, software
 //* distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Collections/Generic/AbstractBlockingQueue.cs
+++ b/src/Spring/Spring.Threading/Threading/Collections/Generic/AbstractBlockingQueue.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Collections/Generic/ArrayBlockingQueue.cs
+++ b/src/Spring/Spring.Threading/Threading/Collections/Generic/ArrayBlockingQueue.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Collections/Generic/BlockingQueueWrapper.cs
+++ b/src/Spring/Spring.Threading/Threading/Collections/Generic/BlockingQueueWrapper.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Collections/Generic/CopyOnWriteArrayList.cs
+++ b/src/Spring/Spring.Threading/Threading/Collections/Generic/CopyOnWriteArrayList.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Collections/Generic/CopyOnWriteList.cs
+++ b/src/Spring/Spring.Threading/Threading/Collections/Generic/CopyOnWriteList.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -434,7 +434,7 @@ namespace Spring.Threading.Collections.Generic
         /// <returns>
         /// The zero-based index of the first occurrence of an element that
         /// matches the conditions defined by <paramref name="match"/>, if
-        /// found; otherwise, –1.
+        /// found; otherwise, ï¿½1.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="match"/> is null.
@@ -458,7 +458,7 @@ namespace Spring.Threading.Collections.Generic
         /// <returns>
         /// The zero-based index of the last occurrence of an element that
         /// matches the conditions defined by <paramref name="match"/>, if
-        /// found; otherwise, –1.
+        /// found; otherwise, ï¿½1.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="match"/> is null.
@@ -487,7 +487,7 @@ namespace Spring.Threading.Collections.Generic
         /// <returns>
         /// The zero-based index of the first occurrence of an element that
         /// matches the conditions defined by <paramref name="match"/>, if
-        /// found; otherwise, –1.
+        /// found; otherwise, ï¿½1.
         /// </returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="index"/> is outside the range of valid indexes for
@@ -522,7 +522,7 @@ namespace Spring.Threading.Collections.Generic
         /// <returns>
         /// The zero-based index of the last occurrence of an element that
         /// matches the conditions defined by <paramref name="match"/>, if
-        /// found; otherwise, –1.
+        /// found; otherwise, ï¿½1.
         /// </returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="index"/> is outside the range of valid indexes for
@@ -560,7 +560,7 @@ namespace Spring.Threading.Collections.Generic
         /// <returns>
         /// The zero-based index of the first occurrence of an element that
         /// matches the conditions defined by <paramref name="match"/>, if
-        /// found; otherwise, –1.
+        /// found; otherwise, ï¿½1.
         /// </returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="index"/> is outside the range of valid indexes for
@@ -605,7 +605,7 @@ namespace Spring.Threading.Collections.Generic
         /// <returns>
         /// The zero-based index of the last occurrence of an element that
         /// matches the conditions defined by <paramref name="match"/>, if
-        /// found; otherwise, –1.
+        /// found; otherwise, ï¿½1.
         /// </returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="index"/> is outside the range of valid indexes for
@@ -699,7 +699,7 @@ namespace Spring.Threading.Collections.Generic
         /// <returns>
         /// The zero-based index of the first occurrence of item within the
         /// range of elements in the <see cref="CopyOnWriteList{T}"/> that
-        /// extends from index to the last element, if found; otherwise, –1.
+        /// extends from index to the last element, if found; otherwise, ï¿½1.
         /// </returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// index is outside the range of valid indexes for the 
@@ -733,7 +733,7 @@ namespace Spring.Threading.Collections.Generic
         /// The zero-based index of the first occurrence of item within the
         /// range of elements in the <see cref="CopyOnWriteList{T}"/> that
         /// starts at index and contains count number of elements, if found;
-        /// otherwise, –1.
+        /// otherwise, ï¿½1.
         /// </returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="index"/> is outside the range of valid indexes for
@@ -1034,7 +1034,7 @@ namespace Spring.Threading.Collections.Generic
         /// </param>
         /// <returns>
         /// The zero-based index of the last occurrence of item within the
-        /// entire <see cref="CopyOnWriteList{T}"/>, if found; otherwise, –1.
+        /// entire <see cref="CopyOnWriteList{T}"/>, if found; otherwise, ï¿½1.
         /// </returns>
         public int LastIndexOf(T item)
         {
@@ -1059,7 +1059,7 @@ namespace Spring.Threading.Collections.Generic
         /// The zero-based index of the last occurrence of item within the
         /// range of elements in the <see cref="CopyOnWriteList{T}"/> that
         /// extends from the first element to <paramref name="index"/>, if
-        /// found; otherwise, –1.
+        /// found; otherwise, ï¿½1.
         /// </returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="index"/> is outside the range of valid indexes for
@@ -1090,7 +1090,7 @@ namespace Spring.Threading.Collections.Generic
         /// The zero-based index of the last occurrence of item within the
         /// range of elements in the <see cref="CopyOnWriteList{T}"/> that
         /// contains <paramref name="count"/> number of elements and ends at
-        /// <paramref name="index"/>, if found; otherwise, –1.
+        /// <paramref name="index"/>, if found; otherwise, ï¿½1.
         /// </returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="index"/> is outside the range of valid indexes for

--- a/src/Spring/Spring.Threading/Threading/Collections/Generic/IBlockingQueue.cs
+++ b/src/Spring/Spring.Threading/Threading/Collections/Generic/IBlockingQueue.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Collections/Generic/LinkedBlockingQueue.cs
+++ b/src/Spring/Spring.Threading/Threading/Collections/Generic/LinkedBlockingQueue.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Collections/Generic/PriorityBlockingQueue.cs
+++ b/src/Spring/Spring.Threading/Threading/Collections/Generic/PriorityBlockingQueue.cs
@@ -13,7 +13,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Collections/Generic/TransformingBlockingQueue.cs
+++ b/src/Spring/Spring.Threading/Threading/Collections/Generic/TransformingBlockingQueue.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/ContextCopyingRunnable.cs
+++ b/src/Spring/Spring.Threading/Threading/ContextCopyingRunnable.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/CountDown.cs
+++ b/src/Spring/Spring.Threading/Threading/CountDown.cs
@@ -1,12 +1,12 @@
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/CountDownLatch.cs
+++ b/src/Spring/Spring.Threading/Threading/CountDownLatch.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/CyclicBarrier.cs
+++ b/src/Spring/Spring.Threading/Threading/CyclicBarrier.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/DefaultChannelCapacity.cs
+++ b/src/Spring/Spring.Threading/Threading/DefaultChannelCapacity.cs
@@ -1,12 +1,12 @@
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/DirectExecutor.cs
+++ b/src/Spring/Spring.Threading/Threading/DirectExecutor.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Execution/AbstractExecutorService.cs
+++ b/src/Spring/Spring.Threading/Threading/Execution/AbstractExecutorService.cs
@@ -7,7 +7,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Execution/ExecutionException.cs
+++ b/src/Spring/Spring.Threading/Threading/Execution/ExecutionException.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Execution/ExecutorCompletionService.cs
+++ b/src/Spring/Spring.Threading/Threading/Execution/ExecutorCompletionService.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Execution/Executors.cs
+++ b/src/Spring/Spring.Threading/Threading/Execution/Executors.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Execution/IExecutorService.cs
+++ b/src/Spring/Spring.Threading/Threading/Execution/IExecutorService.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Execution/ILoopResult.cs
+++ b/src/Spring/Spring.Threading/Threading/Execution/ILoopResult.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Execution/ILoopState.cs
+++ b/src/Spring/Spring.Threading/Threading/Execution/ILoopState.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Execution/ParallelCompletion.cs
+++ b/src/Spring/Spring.Threading/Threading/Execution/ParallelCompletion.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Execution/ParallelCompletionBase.cs
+++ b/src/Spring/Spring.Threading/Threading/Execution/ParallelCompletionBase.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Execution/ParallelExtension.cs
+++ b/src/Spring/Spring.Threading/Threading/Execution/ParallelExtension.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Execution/ParallelOptions.cs
+++ b/src/Spring/Spring.Threading/Threading/Execution/ParallelOptions.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Execution/ThreadPoolExecutor.cs
+++ b/src/Spring/Spring.Threading/Threading/Execution/ThreadPoolExecutor.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/FIFOSemaphore.cs
+++ b/src/Spring/Spring.Threading/Threading/FIFOSemaphore.cs
@@ -1,12 +1,12 @@
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/ForkJoin/FJTask.cs
+++ b/src/Spring/Spring.Threading/Threading/ForkJoin/FJTask.cs
@@ -2,13 +2,13 @@ using System.Threading;
 
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/ForkJoin/FJTaskRunner.cs
+++ b/src/Spring/Spring.Threading/Threading/ForkJoin/FJTaskRunner.cs
@@ -1,12 +1,12 @@
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/ForkJoin/FJTaskRunnerGroup.cs
+++ b/src/Spring/Spring.Threading/Threading/ForkJoin/FJTaskRunnerGroup.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Future/FutureTask.cs
+++ b/src/Spring/Spring.Threading/Threading/Future/FutureTask.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Future/IDelayed.cs
+++ b/src/Spring/Spring.Threading/Threading/Future/IDelayed.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Future/IFuture.cs
+++ b/src/Spring/Spring.Threading/Threading/Future/IFuture.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Future/IRunnableFuture.cs
+++ b/src/Spring/Spring.Threading/Threading/Future/IRunnableFuture.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/FutureResult.cs
+++ b/src/Spring/Spring.Threading/Threading/FutureResult.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Heap.cs
+++ b/src/Spring/Spring.Threading/Threading/Heap.cs
@@ -1,12 +1,12 @@
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Helpers/FIFOWaitQueue.cs
+++ b/src/Spring/Spring.Threading/Threading/Helpers/FIFOWaitQueue.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Helpers/IQueuedSync.cs
+++ b/src/Spring/Spring.Threading/Threading/Helpers/IQueuedSync.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Helpers/IWaitQueue.cs
+++ b/src/Spring/Spring.Threading/Threading/Helpers/IWaitQueue.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Helpers/WaitNode.cs
+++ b/src/Spring/Spring.Threading/Threading/Helpers/WaitNode.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/IBarrier.cs
+++ b/src/Spring/Spring.Threading/Threading/IBarrier.cs
@@ -1,13 +1,13 @@
 #region License
 
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/IBoundedChannel.cs
+++ b/src/Spring/Spring.Threading/Threading/IBoundedChannel.cs
@@ -1,12 +1,12 @@
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/ICallable.cs
+++ b/src/Spring/Spring.Threading/Threading/ICallable.cs
@@ -7,7 +7,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/ICancellable.cs
+++ b/src/Spring/Spring.Threading/Threading/ICancellable.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/IChannel.cs
+++ b/src/Spring/Spring.Threading/Threading/IChannel.cs
@@ -3,13 +3,13 @@ using System.Threading;
 
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/IContextCarrier.cs
+++ b/src/Spring/Spring.Threading/Threading/IContextCarrier.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/IContextCarrierFactory.cs
+++ b/src/Spring/Spring.Threading/Threading/IContextCarrierFactory.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/IExecutor.cs
+++ b/src/Spring/Spring.Threading/Threading/IExecutor.cs
@@ -7,7 +7,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/IPuttable.cs
+++ b/src/Spring/Spring.Threading/Threading/IPuttable.cs
@@ -1,12 +1,12 @@
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/IRunnable.cs
+++ b/src/Spring/Spring.Threading/Threading/IRunnable.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/ITakable.cs
+++ b/src/Spring/Spring.Threading/Threading/ITakable.cs
@@ -1,12 +1,12 @@
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/IThreadFactory.cs
+++ b/src/Spring/Spring.Threading/Threading/IThreadFactory.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/LayeredSync.cs
+++ b/src/Spring/Spring.Threading/Threading/LayeredSync.cs
@@ -1,12 +1,12 @@
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/LinkedNode.cs
+++ b/src/Spring/Spring.Threading/Threading/LinkedNode.cs
@@ -1,12 +1,12 @@
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/LinkedQueue.cs
+++ b/src/Spring/Spring.Threading/Threading/LinkedQueue.cs
@@ -1,12 +1,12 @@
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/LockedExecutor.cs
+++ b/src/Spring/Spring.Threading/Threading/LockedExecutor.cs
@@ -7,7 +7,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Locks/ConditionVariable.cs
+++ b/src/Spring/Spring.Threading/Threading/Locks/ConditionVariable.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Locks/FIFOConditionVariable.cs
+++ b/src/Spring/Spring.Threading/Threading/Locks/FIFOConditionVariable.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Locks/ICondition.cs
+++ b/src/Spring/Spring.Threading/Threading/Locks/ICondition.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Locks/ILock.cs
+++ b/src/Spring/Spring.Threading/Threading/Locks/ILock.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Locks/IReadWriteLock.cs
+++ b/src/Spring/Spring.Threading/Threading/Locks/IReadWriteLock.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Locks/ReentrantLock.cs
+++ b/src/Spring/Spring.Threading/Threading/Locks/ReentrantLock.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/LogicalThreadContextCarrierFactory.cs
+++ b/src/Spring/Spring.Threading/Threading/LogicalThreadContextCarrierFactory.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Mutex.cs
+++ b/src/Spring/Spring.Threading/Threading/Mutex.cs
@@ -1,13 +1,13 @@
 #region License
 
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/NullRunnable.cs
+++ b/src/Spring/Spring.Threading/Threading/NullRunnable.cs
@@ -1,12 +1,12 @@
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/PooledExecutor.cs
+++ b/src/Spring/Spring.Threading/Threading/PooledExecutor.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/PrioritySemaphore.cs
+++ b/src/Spring/Spring.Threading/Threading/PrioritySemaphore.cs
@@ -1,12 +1,12 @@
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/QueuedExecutor.cs
+++ b/src/Spring/Spring.Threading/Threading/QueuedExecutor.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/QueuedSemaphore.cs
+++ b/src/Spring/Spring.Threading/Threading/QueuedSemaphore.cs
@@ -1,12 +1,12 @@
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Rendezvous.cs
+++ b/src/Spring/Spring.Threading/Threading/Rendezvous.cs
@@ -1,12 +1,12 @@
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Runnable.cs
+++ b/src/Spring/Spring.Threading/Threading/Runnable.cs
@@ -7,7 +7,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/SemaphoreControlledChannel.cs
+++ b/src/Spring/Spring.Threading/Threading/SemaphoreControlledChannel.cs
@@ -1,12 +1,12 @@
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/Slot.cs
+++ b/src/Spring/Spring.Threading/Threading/Slot.cs
@@ -1,12 +1,12 @@
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/SynchronousChannel.cs
+++ b/src/Spring/Spring.Threading/Threading/SynchronousChannel.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/ThreadFactoryUser.cs
+++ b/src/Spring/Spring.Threading/Threading/ThreadFactoryUser.cs
@@ -1,12 +1,12 @@
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/ThreadedExecutor.cs
+++ b/src/Spring/Spring.Threading/Threading/ThreadedExecutor.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/TimedCallable.cs
+++ b/src/Spring/Spring.Threading/Threading/TimedCallable.cs
@@ -6,7 +6,7 @@
 //* you may not use this file except in compliance with the License.
 //* You may obtain a copy of the License at
 //* 
-//*      http://www.apache.org/licenses/LICENSE-2.0
+//*      https://www.apache.org/licenses/LICENSE-2.0
 //* 
 //* Unless required by applicable law or agreed to in writing, software
 //* distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/WaitFreeQueue.cs
+++ b/src/Spring/Spring.Threading/Threading/WaitFreeQueue.cs
@@ -1,12 +1,12 @@
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/WaitableRunnable.cs
+++ b/src/Spring/Spring.Threading/Threading/WaitableRunnable.cs
@@ -2,13 +2,13 @@
 
 //#region License
 //*
-//* Copyright © 2002-2005 the original author or authors.
+//* Copyright ï¿½ 2002-2005 the original author or authors.
 //* 
 //* Licensed under the Apache License, Version 2.0 (the "License");
 //* you may not use this file except in compliance with the License.
 //* You may obtain a copy of the License at
 //* 
-//*      http://www.apache.org/licenses/LICENSE-2.0
+//*      https://www.apache.org/licenses/LICENSE-2.0
 //* 
 //* Unless required by applicable law or agreed to in writing, software
 //* distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring/Spring.Threading/Threading/WaiterPreferenceSemaphore.cs
+++ b/src/Spring/Spring.Threading/Threading/WaiterPreferenceSemaphore.cs
@@ -1,12 +1,12 @@
 #region License
 /*
-* Copyright © 2002-2005 the original author or authors.
+* Copyright ï¿½ 2002-2005 the original author or authors.
 * 
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Threading.Tests/Collections/Generic/PriorityQueueTest.cs
+++ b/test/Spring/Spring.Threading.Tests/Collections/Generic/PriorityQueueTest.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Threading.Tests/CoreExceptionTests.cs
+++ b/test/Spring/Spring.Threading.Tests/CoreExceptionTests.cs
@@ -7,7 +7,7 @@
 // * you may not use this file except in compliance with the License.
 // * You may obtain a copy of the License at
 // *
-// *      http://www.apache.org/licenses/LICENSE-2.0
+// *      https://www.apache.org/licenses/LICENSE-2.0
 // *
 // * Unless required by applicable law or agreed to in writing, software
 // * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Threading.Tests/ExceptionsTest.cs
+++ b/test/Spring/Spring.Threading.Tests/ExceptionsTest.cs
@@ -1,13 +1,13 @@
 #region Licence
 
 /*
- * Copyright © 2002-2005 the original author or authors.
+ * Copyright ï¿½ 2002-2005 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Threading.Tests/StandardsComplianceTest.cs
+++ b/test/Spring/Spring.Threading.Tests/StandardsComplianceTest.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicArrayTests.cs
+++ b/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicArrayTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicBooleanTests.cs
+++ b/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicBooleanTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicIntegerArrayTests.cs
+++ b/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicIntegerArrayTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicIntegerTests.cs
+++ b/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicIntegerTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicLongArrayTests.cs
+++ b/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicLongArrayTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicLongTests.cs
+++ b/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicLongTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicMarkableReferenceTests.cs
+++ b/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicMarkableReferenceTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicMarkableTests.cs
+++ b/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicMarkableTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicReferenceArrayTests.cs
+++ b/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicReferenceArrayTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicReferenceTests.cs
+++ b/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicReferenceTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicStampedReferenceTests.cs
+++ b/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicStampedReferenceTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicStampedTests.cs
+++ b/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicStampedTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicTests.cs
+++ b/test/Spring/Spring.Threading.Tests/Threading/AtomicTypes/AtomicTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Threading.Tests/Threading/CallableTest.cs
+++ b/test/Spring/Spring.Threading.Tests/Threading/CallableTest.cs
@@ -7,7 +7,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Threading.Tests/Threading/Collections/Generic/CopyOnWriteListTest.cs
+++ b/test/Spring/Spring.Threading.Tests/Threading/Collections/Generic/CopyOnWriteListTest.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Threading.Tests/Threading/Collections/Generic/DelayQueueTest.cs
+++ b/test/Spring/Spring.Threading.Tests/Threading/Collections/Generic/DelayQueueTest.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Threading.Tests/Threading/Execution/AbstractExecutorServiceTests.cs
+++ b/test/Spring/Spring.Threading.Tests/Threading/Execution/AbstractExecutorServiceTests.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Threading.Tests/Threading/Execution/ExecutorServiceTestFixture.cs
+++ b/test/Spring/Spring.Threading.Tests/Threading/Execution/ExecutorServiceTestFixture.cs
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
@@ -287,7 +287,7 @@ namespace Spring.Threading.Execution
             Assert.That(e.ParamName, Is.EqualTo("call"));
         }
 
-        [Test, Description("Submit(runnable, result£©runs the runnable and sets the future result")]
+        [Test, Description("Submit(runnable, resultï¿½ï¿½runs the runnable and sets the future result")]
         public void SubmitExecutesTheRunnableAndSetFutureResult()
         {
             var future = ExecutorService.Submit(_runnable, TestData<T>.One);
@@ -297,7 +297,7 @@ namespace Spring.Threading.Execution
             JoinPool(ExecutorService);
         }
 
-        [Test, Description("Submit(action, result£©runs the action and sets the future result")]
+        [Test, Description("Submit(action, resultï¿½ï¿½runs the action and sets the future result")]
         public void SubmitExecutesTheActionAndSetFutureResult()
         {
             var future = ExecutorService.Submit(_action, TestData<T>.One);

--- a/test/Spring/Spring.Threading.Tests/Threading/LatchTest.cs
+++ b/test/Spring/Spring.Threading.Tests/Threading/LatchTest.cs
@@ -11,7 +11,7 @@ using NUnit.Framework;
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Threading.Tests/Threading/RunnableTest.cs
+++ b/test/Spring/Spring.Threading.Tests/Threading/RunnableTest.cs
@@ -7,7 +7,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Threading.Tests/Threading/SemaphoreTest.cs
+++ b/test/Spring/Spring.Threading.Tests/Threading/SemaphoreTest.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring/Spring.Threading.Tests/Threading/ThreadInterruptionTest.cs
+++ b/test/Spring/Spring.Threading.Tests/Threading/ThreadInterruptionTest.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 11 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 163 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).